### PR TITLE
Add decorator method to decorated model

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -3,5 +3,6 @@ require 'draper/system'
 require 'draper/all_helpers'
 require 'draper/base'
 require 'draper/lazy_helpers'
+require 'draper/model_support'
 
 Draper::System.setup

--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -21,6 +21,7 @@ module Draper
     
     def self.decorates(input)
       self.model_class = input.to_s.classify.constantize
+      model_class.send :include, Draper::ModelSupport
     end
     
     def self.denies(*input_denied)

--- a/lib/draper/model_support.rb
+++ b/lib/draper/model_support.rb
@@ -1,0 +1,5 @@
+module Draper::ModelSupport
+  def decorator
+    @decorator ||= "#{self.class.name}Decorator".constantize.decorate(self)
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -56,6 +56,12 @@ describe Draper::Base do
     end
   end  
 
+  context 'the decorated model' do
+    it 'receives the mixin' do
+      source.class.ancestors.include?(Draper::ModelSupport)
+    end
+  end
+
   it "should wrap source methods so they still accept blocks" do
     subject.block{"marker"}.should == "marker"
   end

--- a/spec/draper/model_support_spec.rb
+++ b/spec/draper/model_support_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Draper::ModelSupport do
+  subject { Product.new }
+
+  describe '#decorator' do
+    its(:decorator) { should be_kind_of(ProductDecorator) }
+    its(:decorator) { should be(subject.decorator) }
+  end
+end


### PR DESCRIPTION
This commit adds a decorator method to the model being decorated. Essentially the inverse of Base.to_model, this allows for easy resolution of a decorated instance from a model instance.
