### PR TITLE
Errors and warnings about gemspec dependencies

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_development_dependency "rake", "0.8.7"
-  s.add_development_dependency "rspec", "~> 2.0.1"
-  s.add_development_dependency "activesupport", "~> 3.0.9"
-  s.add_development_dependency "actionpack", "~> 3.0.9"
+  s.add_development_dependency "rake", ["0.8.7"]
+  s.add_development_dependency "rspec", ["~> 2.0.1"]
+  s.add_development_dependency "activesupport", ["~> 3.0.9"]
+  s.add_development_dependency "actionpack", ["~> 3.0.9"]
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-rspec"
   s.add_development_dependency "rb-fsevent"
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "launchy"
   else
     s.add_development_dependency "ruby-debug19"
-    s.add_development_dependency 'cover_me', '>= 1.0.0.rc6'
+    s.add_development_dependency 'cover_me', ['>= 1.0.0.rc6']
   end
 end


### PR DESCRIPTION
The gemspec contains invalid version specifications for the development dependencies, preventing it from installing with newer versions of rubygems.
