### PR TITLE
Readme references wrong rails generate command

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -143,7 +143,7 @@ If you want a helper, you can still call `rails generate helper` directly.
 To decorate a model named `Article`:
 
 ```
-rails generate draper:decorator Article
+rails generate draper:model Article
 ```
 
 ### Writing Methods
@@ -252,7 +252,7 @@ First, follow the steps above to add the dependency and update your bundle.
 Since we're talking about the `Article` model we'll create an `ArticleDecorator` class. You could do it by hand, but use the provided generator:
 
 ```
-rails generate draper:decorator Article
+rails generate draper:model Article
 ```
 
 Now open up the created `app/decorators/article_decorator.rb` and you'll find an `ArticleDecorator` class. Add this method:


### PR DESCRIPTION
The Readme refers to:

   rails generate draper:decorator Article

However, this does not work for me using 0.6.0.

I've updated the Readme to reference:

```
rails generate draper:model Article
```

Which appears to work in the same fashion.
