### PR TITLE
replacing helper generator

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -138,15 +138,18 @@ end
 If you want a helper, you can still call `rails generate helper` directly.
 
 
-#### Replace Rails Helper Generation with Decorator Generation (Optional) 
+#### Add DecoratorGenerator to ActiveRecord Generator (Optional) 
 
-If you want to completely replace the helper generation with the decorator generator, just add this to your `config/application.rb`
+Add the following to your `config/application.rb`
 
 ```ruby
 config.generators do |g|
-  g.helper :decorator
+  g.orm :decorator, :invoke_after_finished => "active_record:model"
 end
 ```
+
+From now on, every model you generate will first invoke the DecoratorGenerator. The Decorator will then invoke the active_record:model Generator.
+
 
 ### Generate the Decorator
 

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -1,5 +1,15 @@
 require File.expand_path('../../draper/decorator/decorator_generator.rb', __FILE__)
 class Rails::DecoratorGenerator < Draper::DecoratorGenerator
-
+  
   source_root File.expand_path('../../draper/decorator/templates', __FILE__)
+  
+  class_option :invoke_after_finished, :type => :string, :description => "Generator to invoke when finished"
+
+  def build_model_and_application_decorators
+    super
+    if self.options[:invoke_after_finished]
+      Rails::Generators.invoke(self.options[:invoke_after_finished], [@name, @_initializer.first[1..-1]]) 
+    end
+  end
+
 end


### PR DESCRIPTION
I've included a wrapper for the DecoratorGenerator so that it's accessible inside of the Rails-namespace.

That makes it easy to not just disable default helper generators but to completely replace them with the DecoratorGenerator.
