### PR TITLE
Delegate == to the decorated models

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -125,6 +125,13 @@ module Draper
       @model
     end
 
+    # Delegates == to the decorated models
+    #
+    # @return [Boolean] true if other's model == self's model 
+    def ==(other)
+      @model == other.model
+    end
+
   private
     def select_methods
       specified = self.allowed || (model.public_methods.map{|s| s.to_sym} - denied.map{|s| s.to_sym})

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -132,6 +132,13 @@ describe Draper::Base do
     end
   end
 
+  context('.==') do
+    it "should compare the decorated models" do
+      other = Draper::Base.new(source)
+      subject.should == other
+    end
+  end
+
   describe "a sample usage with denies" do
     let(:subject_with_denies){ DecoratorWithDenies.new(source) }
 


### PR DESCRIPTION
I've found myself needing to do things like person1.model == person2.model all over my code, so letting the decorator do this for me seems like a reasonable solution.
