### PR TITLE
Extreme performance issues with draper

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -139,7 +139,7 @@ module Draper
 
     def respond_to?(method)
       if select_methods.include?(method)
-        model.repsond_to?(method)
+        model.respond_to?(method)
       else
         super
       end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -163,11 +163,11 @@ describe Draper::Base do
     let(:subject_with_allows){ DecoratorWithAllows.new(source) }
 
     it "should echo the allowed method" do
-      subject_with_allows.should respond_to(:upcase)
+      subject_with_allows.should respond_to(:goodnight_moon)
     end
 
     it "should echo _only_ the allowed method" do
-      subject_with_allows.should_not respond_to(:downcase)
+      subject_with_allows.should_not respond_to(:hello_world)
     end
   end
 

--- a/spec/samples/decorator_with_allows.rb
+++ b/spec/samples/decorator_with_allows.rb
@@ -1,3 +1,3 @@
 class DecoratorWithAllows < Draper::Base  
-  allows :upcase
+  allows :goodnight_moon
 end


### PR DESCRIPTION
I've been encountering some extreme performance issues (20x slowdown) when decorating a large number (100+) of models.

![Draper slowdown](http://i.imgur.com/m4IJy.png)

My hunch is that build_methods is culprit, as it builds a singleton class for each decorator, defines hundreds of methods in it, and then has to get GCed. Perhaps it would make more sense to go with a method_missing based approach?

Meanwhile, I've been cheating to get performant code by doing this (which seems to perform as well as the draper-less version):

``` ruby
decorator = Person.new.decorator
render :json => @people.map{|p| decorator.tap{|d| d.model = p}.as_api_json}
```
