### PR TITLE
Remove the fake ActiveRecord's method_missing

### DIFF
--- a/spec/samples/active_record.rb
+++ b/spec/samples/active_record.rb
@@ -1,7 +1,4 @@
 module ActiveRecord
   class Base
-    def method_missing(name, *args)
-      name
-    end
   end
 end


### PR DESCRIPTION
This method is not necessary for the tests to pass, but has led to some false positives (i.e. https://github.com/michaelfairley/draper/commit/533da82a16dd58a7b0082a7f4f4aa45979e4ed8a#L0R142).
