### PR TITLE
Implemented decorated collection proxy

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -93,7 +93,7 @@ module Draper
     # @param [Object] instance(s) to wrap
     # @param [Object] context (optional)
     def self.decorate(input, context = {})
-      input.respond_to?(:each) ? input.map{|i| new(i, context)} : new(input, context)
+      input.respond_to?(:each) ? DecoratedEnumerableProxy.new(input, self, context) : new(input, context)
     end
 
     # Access the helpers proxy to call built-in and user-defined
@@ -158,5 +158,32 @@ module Draper
       specified = self.allowed || (model.public_methods.map{|s| s.to_sym} - denied.map{|s| s.to_sym})
       (specified - self.public_methods.map{|s| s.to_sym}) + FORCED_PROXY
     end
+
+    class DecoratedEnumerableProxy
+      include Enumerable
+
+      def initialize(collection, klass, context)
+        @wrapped_collection, @klass, @context = collection, klass, context
+      end
+
+      # Implementation of Enumerable#each that proxyes to the wrapped collection
+      def each(&block)
+        @wrapped_collection.each { |member| block.call(@klass.new(member, @context)) }
+      end
+
+      # Implement to_arry so that render @decorated_collection is happy
+      def to_ary
+        @wrapped_collection.to_ary
+      end
+
+      def method_missing (meth, *args, &block)
+        @wrapped_collection.send(meth, *args, &block)
+      end
+
+      def to_s
+        "#<DecoratedEnumerableProxy of #{@klass} for #{@wrapped_collection.inspect}>"
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
When decorating collections, returning an array or decorators
for each element is not enough. Often the original collection
is richer then an array, e.g. has pagination methods.
This commit adds DecoratedEnumerableProxy that is returned
when decorating a collection of models, and which proxies
missing methods to the original wrapped collection.
