### PR TITLE
Added #include? to DecoratedEnumerableProxy class

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -127,7 +127,7 @@ module Draper
     #
     # @return [Boolean] true if other's model == self's model 
     def ==(other)
-      @model == other.model
+      @model == (other.respond_to?(:model) ? other.model : other)
     end
 
     def respond_to?(method, include_private = false)

--- a/lib/draper/decorated_enumerable_proxy.rb
+++ b/lib/draper/decorated_enumerable_proxy.rb
@@ -22,10 +22,6 @@ module Draper
       super || @wrapped_collection.respond_to?(method)
     end
 
-    def include?(member)
-      @wrapped_collection.include?(member)
-    end
-
     def to_s
       "#<DecoratedEnumerableProxy of #{@klass} for #{@wrapped_collection.inspect}>"
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -218,10 +218,10 @@ describe Draper::Base do
     it "should return whether the member is in the array for a decorated wrapped collection" do
       # This tests that include? is defined for the DecoratedEnumerableProxy
       member = paged_array.first
-      decorator = ProductDecorator.decorate(paged_array)
-      decorator.respond_to?(:include?)
-      decorator.include?(member).should == true
-      decorator.include?(Product.new).should == false
+      subject.respond_to?(:include?)
+      subject.include?(member).should == true
+      subject.include?(subject.first).should == true
+      subject.include?(Product.new).should == false
     end
   end
 


### PR DESCRIPTION
Added support for DecoratedEnumerableProxy's instance method `#include?` to work with non-decorator objects. 
