### PR TITLE
Include `Draper::ViewContextFilter` in `ActionMailer::Base`

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -229,6 +229,21 @@ Use the new methods in your views like any other model method (ex: `@article.pub
 <h1><%= @article.title %> <%= @article.published_at %></h1>
 ```
 
+### Using in Mailers
+
+To use decorators in mailers that use helpers, you have to call `set_current_view_context` in your
+mailer method:
+
+```ruby
+class ActicleMailer < ActionMailer::Base
+  def new_article(article)
+    set_current_view_context
+    @article_decorator = ArticleDecorator.decorate(article)
+    mail(:to => 'come@me.bro', :subject => "New Article: #{@article_decorator.title}")
+  end
+end
+```
+
 ## Possible Decoration Methods
 
 Here are some ideas of what you might do in decorator methods:

--- a/lib/draper/system.rb
+++ b/lib/draper/system.rb
@@ -1,7 +1,8 @@
 module Draper
-  class System    
+  class System
     def self.setup
       ActionController::Base.send(:include, Draper::ViewContextFilter) if defined?(ActionController::Base)
+      ActionMailer::Base.send(:include, Draper::ViewContextFilter) if defined?(ActionMailer::Base)
     end
   end
 end

--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -8,14 +8,14 @@ module Draper
       Thread.current[:current_view_context] = input
     end
   end
-  
+
   module ViewContextFilter
     def set_current_view_context
       Draper::ViewContext.current = self.view_context
     end
-    
+
     def self.included(source)
-      source.send(:before_filter, :set_current_view_context)
+      source.send(:before_filter, :set_current_view_context) if source.respond_to?(:before_filter)
     end
   end
 end


### PR DESCRIPTION
Currently, `h` will be `nil` when trying to use a decorator in an `ActionMailer::Base`. This pull request includes `Draper::ViewContextFilter` into `ActionMailer::Base` so that `set_view_context` is available to be called.

Since `ActionMailer::Base` doesn't have a `before_filter`, `set_view_context` will have to be called manually. Not the cleanest/most seamless integration, but it will at least work be available to be used in action mailers.

Any ideas about how we can get it into `ActionMailer::Base`s without having to manually run `set_view_context`?
