### PR TITLE
Make CanCan work with Draper Decorators

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -146,6 +146,11 @@ module Draper
       @model == (other.respond_to?(:model) ? other.model : other)
     end
 
+    def kind_of?(klass)
+      return true if klass == model.class
+      super
+    end
+
     def respond_to?(method, include_private = false)
       super || (allow?(method) && model.respond_to?(method))
     end

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -362,4 +362,10 @@ describe Draper::Base do
       decorator.sample_truncate.should == "Once..."
     end
   end
+
+  describe "decorator in cancan rules" do
+    it "should answer yes to kind_of? source class" do
+      subject.kind_of?(source.class).should == true
+    end
+  end
 end


### PR DESCRIPTION
Make decorators be kind_of? their models class, so that cancan rules apply to them.
This makes CanCan seamlessly work with decorators as it would with the corresponding model instances.
