### PR TITLE
Generalize to pass an options hash to decorators

### DIFF
--- a/lib/draper/decorated_enumerable_proxy.rb
+++ b/lib/draper/decorated_enumerable_proxy.rb
@@ -2,16 +2,16 @@ module Draper
   class DecoratedEnumerableProxy
     include Enumerable
 
-    def initialize(collection, klass, context)
-      @wrapped_collection, @klass, @context = collection, klass, context
+    def initialize(collection, klass, options = {})
+      @wrapped_collection, @klass, @options = collection, klass, options
     end
 
     def each(&block)
-      @wrapped_collection.each { |member| block.call(@klass.new(member, @context)) }
+      @wrapped_collection.each { |member| block.call(@klass.new(member, @options)) }
     end
 
     def to_ary
-      @wrapped_collection.map { |member| @klass.new(member, @context) }
+      @wrapped_collection.map { |member| @klass.new(member, @options) }
     end
 
     def method_missing (method, *args, &block)

--- a/lib/draper/model_support.rb
+++ b/lib/draper/model_support.rb
@@ -1,14 +1,14 @@
 module Draper::ModelSupport
-  def decorator
-    @decorator ||= "#{self.class.name}Decorator".constantize.decorate(self)
+  def decorator(options = {})
+    @decorator ||= "#{self.class.name}Decorator".constantize.decorate(self, options)
     block_given? ? yield(@decorator) : @decorator
   end
   
   alias :decorate :decorator
 
   module ClassMethods
-    def decorate(context = {})
-      @decorator_proxy ||= "#{model_name}Decorator".constantize.decorate(self.scoped)
+    def decorate(options = {})
+      @decorator_proxy ||= "#{model_name}Decorator".constantize.decorate(self.scoped, options)
       block_given? ? yield(@decorator_proxy) : @decorator_proxy
     end
   end

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -135,7 +135,7 @@ describe Draper::Base do
     end
 
     it "should accept and store a context" do
-      pd = ProductDecorator.find(1, :admin)
+      pd = ProductDecorator.find(1, :context => :admin)
       pd.context.should == :admin
     end
   end
@@ -164,7 +164,7 @@ describe Draper::Base do
     context "with a context" do
       let(:context) {{ :some => 'data' }}
 
-      subject { Draper::Base.decorate(source, context) }
+      subject { Draper::Base.decorate(source, :context => context) }
 
       context "when given a collection of source objects" do
         let(:source) { [Product.new, Product.new] }
@@ -189,7 +189,7 @@ describe Draper::Base do
       subject.should == other
     end
   end
-  
+
   context 'position accessors' do
     [:first, :last].each do |method|
       context "##{method}" do
@@ -202,9 +202,9 @@ describe Draper::Base do
         end
 
         it "should accept an optional context" do
-          ProductDecorator.send(method, :admin).context.should == :admin
+          ProductDecorator.send(method, :context => :admin).context.should == :admin
         end
-      end      
+      end
     end
   end
 
@@ -273,9 +273,9 @@ describe Draper::Base do
       it "should return a decorated collection" do
         ProductDecorator.all.first.should be_instance_of ProductDecorator
       end
-      
+
       it "should accept a context" do
-        collection = ProductDecorator.all(:admin)
+        collection = ProductDecorator.all(:context => :admin)
         collection.first.context.should == :admin
       end
     end


### PR DESCRIPTION
This is the first step of what we were discussing in regards to get the "inferring" of the decorators for models who are inherited (#40).
