### PR TITLE
Specs at spec/decorators prime the view context

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -6,5 +6,6 @@ require 'draper/model_support'
 require 'draper/helper_support'
 require 'draper/view_context'
 require 'draper/decorated_enumerable_proxy'
+require 'draper/rspec_integration' if defined?(RSpec)
 
 Draper::System.setup

--- a/lib/draper/rspec_integration.rb
+++ b/lib/draper/rspec_integration.rb
@@ -1,0 +1,22 @@
+module Draper
+  module DecoratorExampleGroup
+    extend ActiveSupport::Concern
+    included { metadata[:type] = :decorator }
+  end
+
+  RSpec.configure do |config|
+    # Automatically tag specs in specs/decorators as type: :decorator
+    config.include Draper::DecoratorExampleGroup, type: :decorator, example_group: {
+      file_path: /spec[\\\/]decorators/
+    }
+
+    # Specs tagged type: :decorator set the Draper view context
+    config.around do |example|
+      if :decorator == example.metadata[:type]
+        ApplicationController.new.set_current_view_context
+      end
+      example.call
+    end
+  end
+end
+

--- a/lib/generators/rspec/templates/application_decorator_spec.rb
+++ b/lib/generators/rspec/templates/application_decorator_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
 
 describe ApplicationDecorator do
-  before { ApplicationController.new.set_current_view_context }
 end


### PR DESCRIPTION
This pull request improves Draper's integration with RSpec.
- it configures RSpec to tag tests at `specs/decorators` as type `:decorator`.
- it primes Draper's view context when an example's type is `:decorator`.
- it removes the superseded `before` hook in generated specs.
