### PR TITLE
Explicitly require rspec/core

### DIFF
--- a/lib/draper/rspec_integration.rb
+++ b/lib/draper/rspec_integration.rb
@@ -1,3 +1,5 @@
+require 'rspec/core' # Expose RSpec.configure
+
 module Draper
   module DecoratorExampleGroup
     extend ActiveSupport::Concern


### PR DESCRIPTION
- Solves `RSpec.configure` not being available to cucumber

Pointed out by @ldenman on pull #87
