### PR TITLE
Added notes about RSpec in Readme.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -250,8 +250,10 @@ end
 ### Integration with RSpec
 
 Using the provided generator, Draper will place specs for your new decorator in `spec/decorators/`. 
-By default, specs in `spec/decorators` will be tagged as `type => :decorator`. Any spec tagged as `decorator`
-will run `ApplicationController.new.set_current_view_context` which makes helpers available to the decorator.
+
+By default, specs in `spec/decorators` will be tagged as `type => :decorator`. Any spec tagged as `decorator` will run `ApplicationController.new.set_current_view_context` which makes helpers available to the decorator.
+
+If your decorator specs live somewhere else, which they shouldn't, make sure to tag them with `type => :decorator`. If you don't tag them, Draper's helpers won't be available to your decorator while testing. 
 
 Note: If you're using Spork, you need to `require 'draper/rspec_integration'` in your Spork.prefork block.
 


### PR DESCRIPTION
I added some notes about how the RSpec integration works and why you should tag specs with `:type => :decorator` if they don't live in `spec/decorators/`.

I also added a note about running with Spork.  If you don't explicitly require 'draper/rspec_integration' in Spork's prefork block, the RSpec configuration will not get loaded and the helpers will be nil. 
