### PR TITLE
Don't cache @decorator_proxy in Draper::ModelSupport::ClassMethods#decorate.

### DIFF
--- a/lib/draper/model_support.rb
+++ b/lib/draper/model_support.rb
@@ -8,8 +8,8 @@ module Draper::ModelSupport
 
   module ClassMethods
     def decorate(options = {})
-      @decorator_proxy ||= "#{model_name}Decorator".constantize.decorate(self.scoped, options)
-      block_given? ? yield(@decorator_proxy) : @decorator_proxy
+      decorator_proxy = "#{model_name}Decorator".constantize.decorate(self.scoped, options)
+      block_given? ? yield(decorator_proxy) : decorator_proxy
     end
   end
 

--- a/spec/draper/model_support_spec.rb
+++ b/spec/draper/model_support_spec.rb
@@ -11,29 +11,38 @@ describe Draper::ModelSupport do
       a = Product.new.decorator { |d| d.awesome_title }
       a.should eql "Awesome Title"
     end
-    
+
     it 'should be aliased to .decorate' do
       subject.decorator.model.should == subject.decorate.model
     end
   end
 
-  describe '#decorate - decorate collections of AR objects' do
-    subject { Product.limit }
-    its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
+  describe Draper::ModelSupport::ClassMethods do
+    shared_examples_for "a call to Draper::ModelSupport::ClassMethods#decorate" do
+      subject { klass.limit }
 
-    it "should decorate the collection" do
-      subject.decorate.size.should == 1
-      subject.decorate.to_ary[0].model.should be_a(Product)
+      its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
+
+      it "should decorate the collection" do
+        subject.decorate.size.should == 1
+        subject.decorate.to_ary[0].model.should be_a(klass)
+      end
+
+      it "should return a new instance each time it is called" do
+        subject.decorate.should_not == subject.decorate
+      end
     end
-  end
 
-  describe '#decorate - decorate collections of namespaced AR objects' do
-    subject { Namespace::Product.limit }
-    its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
+    describe '#decorate - decorate collections of AR objects' do
+      let(:klass) { Product }
 
-    it "should decorate the collection" do
-      subject.decorate.size.should == 1
-      subject.decorate.to_ary[0].model.should be_a(Namespace::Product)
+      it_should_behave_like "a call to Draper::ModelSupport::ClassMethods#decorate"
+    end
+
+    describe '#decorate - decorate collections of namespaced AR objects' do
+      let(:klass) { Namespace::Product }
+
+      it_should_behave_like "a call to Draper::ModelSupport::ClassMethods#decorate"
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, calling `Draper::ModelSupport::ClassMethods#decorate` had the unfortunate side
effect of setting `@decorator_proxy` once and never setting it again at the class level. This caused all subsequent calls to `decorate` on `ActiveRecord::Base` descendant classes and their corresponding `ActiveRecord::Relations` to always return this same `DecoratedEnumerableProxy`, which could result in some very odd behavior, e.g. getting a completely different set of decorated models than you would have expected.

I've added specs to verify that this no longer occurs.
