### PR TITLE
Don't call ::scoped on an object if it's already a collection.

### DIFF
--- a/lib/draper/model_support.rb
+++ b/lib/draper/model_support.rb
@@ -8,8 +8,18 @@ module Draper::ModelSupport
 
   module ClassMethods
     def decorate(options = {})
-      @decorator_proxy ||= "#{model_name}Decorator".constantize.decorate(self.scoped, options)
+      @decorator_proxy = __decorator_proxy__(options)
       block_given? ? yield(@decorator_proxy) : @decorator_proxy
+    end
+
+  private
+
+    def __decorator_proxy__(options)
+      "#{model_name}Decorator".constantize.decorate(__object_to_decorate__, options)
+    end
+
+    def __object_to_decorate__
+      self.respond_to?(:each) ? self : self.scoped
     end
   end
 

--- a/spec/draper/model_support_spec.rb
+++ b/spec/draper/model_support_spec.rb
@@ -11,29 +11,64 @@ describe Draper::ModelSupport do
       a = Product.new.decorator { |d| d.awesome_title }
       a.should eql "Awesome Title"
     end
-    
+
     it 'should be aliased to .decorate' do
       subject.decorator.model.should == subject.decorate.model
     end
   end
 
-  describe '#decorate - decorate collections of AR objects' do
-    subject { Product.limit }
-    its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
+  describe Draper::ModelSupport::ClassMethods do
+    shared_examples_for "a method that creates a DecoratedEnumerableProxy" do
+      its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
 
-    it "should decorate the collection" do
-      subject.decorate.size.should == 1
-      subject.decorate.to_ary[0].model.should be_a(Product)
+      it "should decorate the collection" do
+        subject.decorate.size.should == 1
+        subject.decorate.to_ary[0].model.should be_a(subject)
+      end
     end
-  end
 
-  describe '#decorate - decorate collections of namespaced AR objects' do
-    subject { Namespace::Product.limit }
-    its(:decorate) { should be_kind_of(Draper::DecoratedEnumerableProxy) }
+    shared_examples_for "a method that decorates an AR model class" do
+      it "should call ::scoped" do
+        subject.should_receive(:scoped)
+        subject.decorate
+      end
 
-    it "should decorate the collection" do
-      subject.decorate.size.should == 1
-      subject.decorate.to_ary[0].model.should be_a(Namespace::Product)
+      it_should_behave_like "a method that creates a DecoratedEnumerableProxy"
+    end
+
+    describe '#decorate - decorate an AR model class' do
+      subject { Product }
+
+      it_should_behave_like "a method that decorates an AR model class"
+    end
+
+    describe '#decorate - decorate a namespaced AR model class' do
+      subject { Namespace::Product }
+
+      it_should_behave_like "a method that decorates an AR model class"
+    end
+
+    shared_examples_for "a method that decorates a collection of AR objects" do
+      subject { klass.limit }
+
+      it "should not call ::scoped" do
+        subject.should_not_receive(:scoped)
+        subject.decorate
+      end
+
+      it_should_behave_like "a method that creates a DecoratedEnumerableProxy"
+    end
+
+    describe '#decorate - decorate collections of AR objects' do
+      let(:klass) { Product }
+
+      it_should_behave_like "a method that decorates a collection of AR objects"
+    end
+
+    describe '#decorate - decorate collections of namespaced AR objects' do
+      let(:klass) { Namespace::Product }
+
+      it_should_behave_like "a method that decorates a collection of AR objects"
     end
   end
 end

--- a/spec/support/samples/active_record.rb
+++ b/spec/support/samples/active_record.rb
@@ -2,7 +2,12 @@ module ActiveRecord
   class Base
 
     def self.limit
-      self
+      tap do
+        instance_eval do
+          @collection = [new]
+          singleton_class.delegate :each, :size, :map, :to => :@collection
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Before this commit, Draper::ModelSupport::ClassMethods#decorate calls
::scoped on the class that it was called upon, regardless of whether or
not it was already a collection. This has the property of removing any
extensions to the collection that may have already been applied, e.g. by
a pagination extension. Check for the presence of the :each method to
check if this is already a collection and decorate it directly if so.
