### PR TITLE
NoMethodError swallowed from inside delegated methods

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -197,8 +197,9 @@ module Draper
             model.send(method, *args, &block)
           end
           self.send(method, *args, &block)
-        rescue NoMethodError
-          super
+        rescue NoMethodError => no_method_error
+          super if no_method_error.name == method
+          raise no_method_error
         end
       else
         super

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -551,6 +551,18 @@ describe Draper::Base do
         subject.hello_world
       end
     end
+
+    context "when the delegated method calls a non-existant method" do
+      it "raises the correct NoMethodError" do
+        begin
+          subject.some_action
+        rescue NoMethodError => e
+          e.name.should_not == :some_action
+        else
+          fail("No exception raised")
+        end
+      end
+    end
   end
 
   describe "#kind_of?" do

--- a/spec/support/samples/product.rb
+++ b/spec/support/samples/product.rb
@@ -45,6 +45,10 @@ class Product < ActiveRecord::Base
     "Sample Title"
   end
 
+  def some_action
+    self.nonexistant_method
+  end
+
   def block
     yield
   end


### PR DESCRIPTION
If a delegated method, calls a missing method inside the source class the NoMethodError is being swallowed by Draper::Base#method_missing.

This can break the BDD workflow as the incorrect NoMethodError is raised.

Pull request contains a small patch to ensure the expected exception is raised.
