### PR TITLE
Convert Draper to using a Railtie for loading

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -7,5 +7,5 @@ require 'draper/helper_support'
 require 'draper/view_context'
 require 'draper/decorated_enumerable_proxy'
 require 'draper/rspec_integration' if defined?(RSpec) and RSpec.respond_to?(:configure)
+require 'draper/railtie'
 
-Draper::System.setup

--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -1,0 +1,19 @@
+require 'rails/railtie'
+
+module Draper
+  class Railtie < Rails::Railtie
+
+    initializer "draper.extend_action_controller_base" do |app|
+      ActiveSupport.on_load(:action_controller) do
+        Draper::System.setup(:action_controller)
+      end
+    end
+
+    initializer "draper.extend_action_mailer_base" do |app|
+      ActiveSupport.on_load(:action_mailer) do
+        Draper::System.setup(:action_mailer)
+      end
+    end
+
+  end
+end

--- a/lib/draper/system.rb
+++ b/lib/draper/system.rb
@@ -1,9 +1,12 @@
 module Draper
   class System
-    def self.setup
-      ActionController::Base.send(:include, Draper::ViewContextFilter) if defined?(ActionController::Base)
-      ActionMailer::Base.send(:include, Draper::ViewContextFilter) if defined?(ActionMailer::Base)
-      ActionController::Base.send(:helper, Draper::HelperSupport) if defined?(ActionController::Base)
+    def self.setup(component)
+      if component == :action_controller
+        ActionController::Base.send(:include, Draper::ViewContextFilter)
+        ActionController::Base.extend(Draper::HelperSupport)
+      elsif component == :action_mailer
+        ActionMailer::Base.send(:include, Draper::ViewContextFilter)
+      end
     end
   end
 end

--- a/spec/support/samples/application_controller.rb
+++ b/spec/support/samples/application_controller.rb
@@ -9,11 +9,10 @@ module ActionController
     def self.before_filter(name)
       @@before_filters << name
     end
-    def self.helper(mod)
-      extend mod
-    end
   end
 end
+
+Draper::System.setup(:action_controller)
 
 class ApplicationController < ActionController::Base
   extend ActionView::Helpers
@@ -42,5 +41,3 @@ class ApplicationController < ActionController::Base
     @@capture ||= false
   end
 end
-
-Draper::System.setup


### PR DESCRIPTION
Whilst debugging a load issue with Decorators in our app, we noted that Draper wasn't using a Railtie to inject itself into Rails. So we thought we'd fix that.

This would allow access to a decorator from a model without the that decorator class has been referenced. 

Cheers,
Kevin and Stephen
