### PR TITLE
Pass options of self.decorates_association to self.decorate

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -69,7 +69,7 @@ module Draper
           options[:with].decorate(orig_association)
         else
           reflection = model.class.reflect_on_association(association_symbol)
-          "#{reflection.klass}Decorator".constantize.decorate(orig_association)
+          "#{reflection.klass}Decorator".constantize.decorate(orig_association, options)
         end
       end
     end


### PR DESCRIPTION
This allows to set { infer: true } in self.decorates_association and in turn decorate each member of polymorphic association with decorator inferred from its own class.

``` ruby
class DocumentDecorator < ApplicationDecorator
    decorates_association :items, { infer: true }
end
```
