### PR TITLE
Add methods to enable will_paginate compatibility

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -193,6 +193,23 @@ module Draper
       @model
     end
 
+    def page(num)
+      @model.page(num)
+    end
+
+    def paginate(options)
+      @model.paginate(options)
+    end
+
+    def current_page
+      @model.current_page
+    end
+
+    def curent_page=(value)
+      @model.current_page = value
+    end
+
+
     # Delegates == to the decorated models
     #
     # @return [Boolean] true if other's model == self's model


### PR DESCRIPTION
The will_paginate issue was that the Base class did not have methods in place to delegate paginating responsibility back to the core model.  I set up the Base class so that it sets and retrieves current_page on the decorated model directly, so that users will be able to paginate via both decorated and undecorated model calls.
