### PR TITLE
Add redcarpet as a development dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,8 @@ gem 'guard-rspec'
 gem 'launchy'
 gem 'yard'
 
+group :development do
+  gem 'redcarpet'
+end
+
 gemspec

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_dependency('activesupport', '>= 2.3.10')
+  s.add_development_dependency('redcarpet')
 end


### PR DESCRIPTION
Attempted to generate the docs with yard and was greeting with `Missing 'redcarpet' gem for Markdown formatting.`

The attached commit simply adds the redcarpet gem as a development dependency.
