### PR TITLE
Proxy all dynamic finders

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -230,7 +230,7 @@ module Draper
     end
 
     def self.method_missing(method, *args, &block)
-      if method.to_s.match(/^find_by.*/)
+      if method.to_s.match(/^find_((all_|last_)?by_|or_(initialize|create)_by_).*/)
         self.decorate(model_class.send(method, *args, &block))
       else
         model_class.send(method, *args, &block)

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -264,6 +264,26 @@ describe Draper::Base do
       ProductDecorator.find_by_name_and_size("apples", "large")
     end
 
+    it "runs find_all_by_(x) finders" do
+      Product.should_receive(:find_all_by_name_and_size)
+      ProductDecorator.find_all_by_name_and_size("apples", "large")
+    end
+
+    it "runs find_last_by_(x) finders" do
+      Product.should_receive(:find_last_by_name_and_size)
+      ProductDecorator.find_last_by_name_and_size("apples", "large")
+    end
+
+    it "runs find_or_initialize_by_(x) finders" do
+      Product.should_receive(:find_or_initialize_by_name_and_size)
+      ProductDecorator.find_or_initialize_by_name_and_size("apples", "large")
+    end
+
+    it "runs find_or_create_by_(x) finders" do
+      Product.should_receive(:find_or_create_by_name_and_size)
+      ProductDecorator.find_or_create_by_name_and_size("apples", "large")
+    end
+
     it "accepts an options hash" do
       Product.should_receive(:find_by_name_and_size).with("apples", "large", {:role => :admin})
       ProductDecorator.find_by_name_and_size("apples", "large", {:role => :admin})


### PR DESCRIPTION
Hi!

Active record allows several different finders:
- find_by
- find_(all|last)_by
- find_or(create|initialize)_by

This commit allows all those forms to be proxied to the decorated object.
What do you think ?

Best regards,
Dominique
