### PR TITLE
remove set_current_view_context from rspec generator

### DIFF
--- a/lib/generators/draper/decorator/templates/decorator_spec.rb
+++ b/lib/generators/draper/decorator/templates/decorator_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
 
 describe <%= resource_name.singularize.camelize %>Decorator do
-  before { ApplicationController.new.set_current_view_context }
 end


### PR DESCRIPTION
looks like we call it in rspec tests by setting `metadata[:type] = :decorator`
