### PR TITLE
Add the missing step in the "Up and Running" section of the readme

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -151,7 +151,7 @@ Then run `bundle` from the project directory.
 This will create the `app/decorators` directory and the `ApplicationDecorator` inside it.
 
 ```
-rails generate drapper:install
+rails generate draper:install
 ```
 
 ### Generate the Decorator


### PR DESCRIPTION
In the "Up and Running" section of the readme, the command `rails generate draper:install` is missing, so I added it in this commit. It's more easy to understand for newcomers (like me).
