### PR TITLE
Fixes typo in README advocating incorrect usage of the generator

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -159,7 +159,7 @@ rails generate draper:install
 To decorate a model named `Article`:
 
 ```
-rails generate draper:decorator Article
+rails generate draper:decorator article
 ```
 
 ### Writing Methods


### PR DESCRIPTION
Quick patch to fix a typo in the README that instructs the user to run the generator like so:

``` bash
rails generate draper:decorator Article
```

...when in fact it should be used like:

``` bash
rails generate draper:decorator article
```
