### PR TITLE
Add a TestRequest and params hash to Draper RSpec tests

### DIFF
--- a/lib/draper/rspec_integration.rb
+++ b/lib/draper/rspec_integration.rb
@@ -14,6 +14,9 @@ module Draper
     config.around do |example|
       if :decorator == example.metadata[:type]
         ApplicationController.new.set_current_view_context
+        Draper::ViewContext.current.controller.request ||= ActionController::TestRequest.new
+        Draper::ViewContext.current.request            ||= Draper::ViewContext.current.controller.request
+        Draper::ViewContext.current.params             ||= {}
       end
       example.call
     end


### PR DESCRIPTION
The current Draper RSpec integration sets the view context to an instance of ApplicationController, but does so without a controller request, view context request, or params hash. This patch simply adds them, allowing decorators that use values from the calling request (ie, subdomain) or params hash to be properly tested with RSpec.
