### PR TITLE
Update `draper.gemspec`

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '~> 3.2'
   s.add_dependency 'rake', '~> 0.9.2'
   s.add_dependency 'rspec', '~> 2.10'
-  s.add_dependency 'activesupport', '~> 3.2'
   s.add_dependency 'actionpack', '~> 3.2'
 
   s.add_development_dependency 'ammeter', '~> 0.2.2'


### PR DESCRIPTION
Commit: 'remove duplicated "activesupport" dependency from the gemspec'

The dependency on `ActiveSupport` was duplicated in `draper.gemspec`

This commit removes the duplicate dependency.
