### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.data
 coverage/*
 .yardoc
 tmp
+vendor/bundle


### PR DESCRIPTION
Commit: 'add vendor/bundle to the .gitignore for Draper devs vendoring gems local...ly using bundler'

A benign update to the `.gitignore` allowing devs working on `Draper` who vendor gems locally in the `Bundler` standard directory `vendor/bundle` to not worry about committing gem sources.
