### PR TITLE
Include view and helper extensions in current context

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -36,13 +36,13 @@ module Draper
 
     initializer "draper.extend_action_controller_base" do |app|
       ActiveSupport.on_load(:action_controller) do
-        Draper::System.setup(:action_controller)
+        Draper::System.setup(self)
       end
     end
 
     initializer "draper.extend_action_mailer_base" do |app|
       ActiveSupport.on_load(:action_mailer) do
-        Draper::System.setup(:action_mailer)
+        Draper::System.setup(self)
       end
     end
 

--- a/lib/draper/system.rb
+++ b/lib/draper/system.rb
@@ -10,11 +10,9 @@ module Draper
     end
 
     def self.setup(component)
-      if component == :action_controller
-        ActionController::Base.send(:include, Draper::ViewContextFilter)
-        ActionController::Base.extend(Draper::HelperSupport)
-      elsif component == :action_mailer
-        ActionMailer::Base.send(:include, Draper::ViewContextFilter)
+      component.class_eval do
+        include Draper::ViewContextFilter
+        extend  Draper::HelperSupport unless defined?(::ActionMailer) && self.is_a?(::ActionMailer::Base)
       end
     end
   end

--- a/spec/support/samples/application_controller.rb
+++ b/spec/support/samples/application_controller.rb
@@ -9,10 +9,10 @@ module ActionController
     def self.before_filter(name)
       @@before_filters << name
     end
+
+    Draper::System.setup(self)
   end
 end
-
-Draper::System.setup(:action_controller)
 
 class ApplicationController < ActionController::Base
   extend ActionView::Helpers


### PR DESCRIPTION
Instead of including extensions in hardcoded `ActionController::Base`, use the current context from AS on_load hook, which in most cases should be `ActionController::Base`, but may change in scenarios such as `ActionController::API` (using the rails-api gem).

See spastorino/rails-api#28 for more info. Let me know if anything can be improved, thanks.

Closes #212
