### PR TITLE
Rename duplicated "block" variable to make rubinius happy

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -213,8 +213,8 @@ module Draper
       super unless allow?(method)
 
       if model.respond_to?(method)
-        self.class.send :define_method, method do |*args, &block|
-          model.send method, *args, &block
+        self.class.send :define_method, method do |*args, &blokk|
+          model.send method, *args, &blokk
         end
 
         send method, *args, &block


### PR DESCRIPTION
See related issue: https://github.com/rubinius/rubinius/issues/1692
I know that is not draper's fault but this fix would allow rubinius users use drapper until they fix the syntax error problem in rubinius itself.
