### PR TITLE
make specs order independed

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--order rand

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -712,10 +712,10 @@ describe Draper::Base do
     end
 
     context "when #hello_world is called again" do
-      before { subject.hello_world }
       it "proxies method directly after first hit" do
-        subject.should_not_receive(:method_missing)
+        subject.methods.should_not include(:hello_world)
         subject.hello_world
+        subject.methods.should include(:hello_world)
       end
     end
 

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -45,6 +45,10 @@ describe Rails::Generators::DecoratorGenerator do
        run_generator ["YourModel"]
       end
 
+      after do
+        Object.send(:remove_const, :ApplicationDecorator)
+      end
+
       subject { file('app/decorators/your_model_decorator.rb') }
       it { should exist }
       it { should contain "class YourModelDecorator < ApplicationDecorator" }


### PR DESCRIPTION
right now 2 tests fail with `--order rand` rspec option. This PR fixes it.
