### PR TITLE
Ammeter v0.2.6 breaks Draper's specs.

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '~> 3.2'
   s.add_dependency 'actionpack', '~> 3.2'
 
-  s.add_development_dependency 'ammeter', '~> 0.2.2'
+  s.add_development_dependency 'ammeter', '0.2.2'
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rspec', '~> 2.10'
   s.add_development_dependency 'yard'


### PR DESCRIPTION
Hi!

After a long hiatus, I am back :) First thing I did is pull down the latest, bundle, rake and .... ooops!

I tightened the gemspec to a known good version.

**SOAPBOX** Checking the `Gemfile.lock` in solves this nicely. Yes, I know that is not best practice in the community. In this case, the community is wrong :)
