### PR TITLE
fix problem with html_escape being private

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -161,12 +161,30 @@ module Draper
       decorate(model_class.last, options)
     end
 
+    # Some helpers are private, for example html_escape... as a workaround
+    # we are wrapping the helpers in a delegator that passes the methods
+    # along through a send, which will ignore private/public distinctions
+    class HelpersWrapper
+      def initialize(helpers)
+        @helpers = helpers
+      end
+
+      def method_missing(method, *args, &block)
+        @helpers.send(method, *args, &block)
+      end
+
+      #needed for tests
+      def ==(other)
+        other.instance_variable_get(:@helpers) == @helpers
+      end
+    end
+
     # Access the helpers proxy to call built-in and user-defined
     # Rails helpers. Aliased to `.h` for convenience.
     #
     # @return [Object] proxy
     def helpers
-      self.class.helpers
+      HelpersWrapper.new self.class.helpers
     end
     alias :h :helpers
 

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -706,8 +706,12 @@ describe Draper::Base do
 
     it "is able to use l rather than helpers.l" do
       now = Time.now
-      decorator.helpers.should_receive(:localize).with(now)
+      decorator.helpers.instance_variable_get(:@helpers).should_receive(:localize).with(now)
       decorator.l now
+    end
+
+    it "is able to access html_escape, a private method" do
+      decorator.sample_html_escaped_text.should == '&lt;script&gt;danger&lt;/script&gt;'
     end
   end
 

--- a/spec/support/samples/application_helper.rb
+++ b/spec/support/samples/application_helper.rb
@@ -1,4 +1,7 @@
+require 'active_support/core_ext/string/output_safety.rb'
 module ApplicationHelper
+  include ERB::Util
+
   def hello_world
     "Hello, World!"
   end

--- a/spec/support/samples/decorator_with_application_helper.rb
+++ b/spec/support/samples/decorator_with_application_helper.rb
@@ -18,4 +18,8 @@ class DecoratorWithApplicationHelper < Draper::Base
   def length
     "overridden"
   end
+
+  def sample_html_escaped_text
+    h.html_escape '<script>danger</script>'
+  end
 end


### PR DESCRIPTION
- wrap the helpers in a simple object that publicizes all methods by
  calling send on method_missing
