### PR TITLE
Pass options to decorates_associations

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -88,7 +88,8 @@ module Draper
     #
     # @param [Symbols*] name of associations to decorate
     def self.decorates_associations(*association_symbols)
-      association_symbols.each{ |sym| decorates_association(sym) }
+      options = association_symbols.extract_options!
+      association_symbols.each{ |sym| decorates_association(sym, options) }
     end
 
     # Specifies a black list of methods which may *not* be proxied to

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -183,10 +183,17 @@ describe Draper::Base do
   context('.decorates_associations') do
     subject { Decorator }
     it "decorates each of the associations" do
-      subject.should_receive(:decorates_association).with(:similar_products)
-      subject.should_receive(:decorates_association).with(:previous_version)
+      subject.should_receive(:decorates_association).with(:similar_products, {})
+      subject.should_receive(:decorates_association).with(:previous_version, {})
 
       subject.decorates_associations :similar_products, :previous_version
+    end
+
+    it "dispatches options" do
+      subject.should_receive(:decorates_association).with(:similar_products, :with => ProductDecorator)
+      subject.should_receive(:decorates_association).with(:previous_version, :with => ProductDecorator)
+
+      subject.decorates_associations :similar_products, :previous_version, :with => ProductDecorator
     end
   end
 


### PR DESCRIPTION
Allows options to be given to `decorates_associations` so that instead of

``` ruby
decorates_association :something, with: ThingDecorator
decorates_association :anything, with: ThingDecorator
```

we can have

``` ruby
decorates_associations :something, :anything, with: ThingDecorator
```
