### PR TITLE
Use the before_setup hook when it is available.

### DIFF
--- a/lib/draper/test/minitest_integration.rb
+++ b/lib/draper/test/minitest_integration.rb
@@ -9,7 +9,16 @@ module MiniTest
 end
 
 class MiniTest::Unit::DecoratorTestCase < MiniTest::Unit::TestCase
-  add_setup_hook { Draper::ViewContext.infect!(self) }
+  if method_defined?(:before_setup)
+    # for minitext >= 2.11
+    def before_setup
+      super
+      Draper::ViewContext.infect!(self)
+    end
+  else
+    # for older minitest, like what ships w/Ruby 1.9
+    add_setup_hook { Draper::ViewContext.infect!(self) }
+  end
 end
 
 MiniTest::Spec.register_spec_type(MiniTest::Spec::Decorator) do |desc|


### PR DESCRIPTION
As of minitest 3.3 the `add_setup_hook` (and friends) are deprecated. Ruby 1.9 ships with an older version of minitest from before the new hooks were added, so we only use the `before_setup` hook when it is available, falling back to the old hooks for older minitests.
