### PR TITLE
Fixed view_context priming. Fixes #244, relates to 057ab4e8.

### DIFF
--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -1,7 +1,7 @@
 module Draper
   module ViewContext
     def self.current
-      Thread.current[:current_view_context] || view_context
+      Thread.current[:current_view_context] || ApplicationController.new.view_context
     end
 
     def self.current=(input)

--- a/spec/draper/view_context_spec.rb
+++ b/spec/draper/view_context_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'draper/test/view_context'
 
 describe Draper::ViewContext do
+  before(:each) do
+    Thread.current[:current_view_context] = nil
+  end
+
   let(:app_controller) { ApplicationController }
   let(:app_controller_instance) { app_controller.new }
 
@@ -12,5 +16,15 @@ describe Draper::ViewContext do
   it "copies the controller's view context to draper" do
     ctx = app_controller_instance.view_context
     Draper::ViewContext.current.should == ctx
+  end
+
+  describe "view_context priming" do
+    let(:app_controller_instance) { double(ApplicationController, :view_context => view_context) }
+    let(:view_context) { double("ApplicationController#view_context") }
+
+    it "primes the view_context when nil" do
+      app_controller.should_receive(:new).and_return(app_controller_instance)
+      Draper::ViewContext.current.should == view_context
+    end
   end
 end


### PR DESCRIPTION
Fix in 057ab4e8 resulted in a "NameError: undefined local variable or method `view_context' for Draper::ViewContext:Module".

References:
- Pull request #241 changes the way view_context is set up
- Issue #244: 057ab4e8 attempts to prime the view_context when not set. However, "current" is a class method, while "view_context" is an instance method.

Added failing spec.
