### PR TITLE
Wrap relation calls and scope calls in decorators

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -256,7 +256,7 @@ module Draper
       if model.respond_to?(method)
         self.class.send :define_method, method do |*args, &blokk|
           result = model.send method, *args, &blokk
-          if result.class.name == "ActiveRecord::Relation"
+          if defined?(ActiveRecord) && result.kind_of?(ActiveRecord::Relation)
             self.class.new(model,self.options)
           else
             result
@@ -275,7 +275,8 @@ module Draper
 
     def self.method_missing(method, *args, &block)
       model_result = model_class.send(method, *args, &block)
-      if model_result.is_a?(model_class) || model_result.class.name == 'ActiveRecord::Relation'
+      if model_result.kind_of?(model_class) ||
+        (defined?(ActiveRecord) && model_result.kind_of?(ActiveRecord::Relation))
         self.decorate(model_result, :context => args.dup.extract_options!)
       else
         model_result

--- a/lib/draper/decorated_enumerable_proxy.rb
+++ b/lib/draper/decorated_enumerable_proxy.rb
@@ -28,7 +28,7 @@ module Draper
       if @wrapped_collection.respond_to?(method)
         self.class.send :define_method, method do |*args, &blokk|
           scoped_result = @wrapped_collection.send(method, *args, &block)
-          if scoped_result.class.name == "ActiveRecord::Relation"
+          if defined?(ActiveRecord) && scoped_result.kind_of?(ActiveRecord::Relation)
             self.class.new(scoped_result, @klass, @options)
           else
             scoped_result

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -51,7 +51,6 @@ describe Draper::Base do
     end
 
     it "returns a Decorator when a scope is called on decorated object" do
-       class ActiveRecord::Relation; end
        proxy = ProductDecorator.new(source)
        klass = proxy.model.class
        klass.class_eval { def some_scope ; ActiveRecord::Relation.new ; end }
@@ -59,7 +58,6 @@ describe Draper::Base do
     end
 
     it "returns a Decorator when a scope is called on the decorator" do
-      class ActiveRecord::Relation; end
       proxy = ProductDecorator
       klass = source.class
       klass.class_eval { def self.some_scope ; ActiveRecord::Relation.new ; end }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,3 +34,8 @@ module ActionController
     Draper::System.setup(self)
   end
 end
+
+module ActiveRecord
+  class Relation
+  end
+end


### PR DESCRIPTION
- wrap model in decorator when scope is called on decorator
- decorate named scope calls on decorators and enumerable proxies

for example,

``` ruby
ProductDecorator.where(name: "Something").first
```

will return an instance of `ProductDecorator`

also,

``` ruby
@product_decorator.some_relation
```

will return a decorated enumerable proxy

Related to issue #128 .
