### PR TITLE
Decorate struct objects correctly

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -148,7 +148,7 @@ module Draper
       if input.instance_of?(self)
         input.options = options unless options.empty?
         return input
-      elsif input.respond_to?(:each) && (!defined?(Sequel) || !input.is_a?(Sequel::Model))
+      elsif input.respond_to?(:each) && !input.is_a?(Struct) && (!defined?(Sequel) || !input.is_a?(Sequel::Model))
         Draper::DecoratedEnumerableProxy.new(input, self, options)
       elsif options[:infer]
         input.decorator(options)

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -401,6 +401,15 @@ describe Draper::Base do
         end
       end
 
+      context "when given a struct" do
+        # Struct objects implement #each
+        let(:source) { Struct.new(:title).new("Godzilla") }
+
+        it "returns a wrapped object" do
+          subject.should be_instance_of(Draper::Base)
+        end
+      end
+
       context "when given a collection of sequel models" do
         # Sequel models implement #each
         let(:source) { [SequelProduct.new, SequelProduct.new] }


### PR DESCRIPTION
Struct objects implement #each, but they should not be decorated using
DecoratedEnumerableProxy.
