### PR TITLE
Separate ViewContext get/create context behavior

### DIFF
--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -1,13 +1,7 @@
 module Draper
   module ViewContext
     def self.current
-      context = Thread.current[:current_view_context]
-      context ||= ApplicationController.new.view_context
-      context.controller.request ||= ActionController::TestRequest.new
-      context.request            ||= context.controller.request
-      context.params             ||= {}
-      Thread.current[:current_view_context] = context
-      context
+      Thread.current[:current_view_context] ||= build_view_context
     end
 
     def self.current=(input)
@@ -17,6 +11,16 @@ module Draper
     def view_context
       super.tap do |context|
         Draper::ViewContext.current = context
+      end
+    end
+    
+    private
+    
+    def build_view_context
+      ApplicationController.new.view_context.tap do |context|
+        context.controller.request ||= ActionController::TestRequest.new
+        context.request            ||= context.controller.request
+        context.params             ||= {}
       end
     end
   end


### PR DESCRIPTION
Separating these behaviors eliminates and entire class of bugs around proper memoization by performing memoization in one place and building the new value in another place. It also makes it more obvious that `self.current` is, in fact, memoizing because it follows a familiar pattern for memoization: `@foo ||= build_foo`.
