### PR TITLE
Added `decorator_class` class and instance methods

### DIFF
--- a/lib/draper/model_support.rb
+++ b/lib/draper/model_support.rb
@@ -2,16 +2,24 @@ module Draper::ModelSupport
   extend ActiveSupport::Concern
 
   def decorator(options = {})
-    @decorator ||= "#{self.class.name}Decorator".constantize.decorate(self, options.merge(:infer => false))
+    @decorator ||= decorator_class.decorate(self, options.merge(:infer => false))
     block_given? ? yield(@decorator) : @decorator
+  end
+
+  def decorator_class
+    "#{self.class.name}Decorator".constantize
   end
 
   alias :decorate :decorator
 
   module ClassMethods
     def decorate(options = {})
-      decorator_proxy = "#{model_name}Decorator".constantize.decorate(self.scoped, options)
+      decorator_proxy = decorator_class.decorate(self.scoped, options)
       block_given? ? yield(decorator_proxy) : decorator_proxy
+    end
+
+    def decorator_class
+      "#{model_name}Decorator".constantize
     end
   end
 end


### PR DESCRIPTION
This is useful when you want to be able to conditionally specify which decorator class to use for a model by overriding `decorator_class`. For example:

```
class User < ActiveRecord::Base
  def decorator_class
    if self.gender == 'male'
      MaleUserDecorator
    else
      FemaleUserDecorator
    end
  end
end

User.create gender: 'male'
User.first.decorate  ->  MaleUserDecorator
```
