### PR TITLE
Delegate DecoratedEnumerableProxy#in_groups_of to the decorated collection

### DIFF
--- a/lib/draper/decorated_enumerable_proxy.rb
+++ b/lib/draper/decorated_enumerable_proxy.rb
@@ -3,7 +3,7 @@ module Draper
   class DecoratedEnumerableProxy
     include Enumerable
 
-    delegate :as_json, :collect, :map, :each, :[], :all?, :include?, :first, :last, :shift, :to => :decorated_collection
+    delegate :as_json, :collect, :map, :each, :[], :all?, :include?, :first, :last, :shift, :in_groups_of, :to => :decorated_collection
 
     # Initialize a new collection decorator instance by passing in
     # an instance of a collection. Pass in an optional


### PR DESCRIPTION
Currently, calling `#in_groups_of` on a DecoratedEnumerableProxy is handled by `method_missing` and proxied to the underlying collection:

``` ruby
@awesome_users = UserDecorator.decorate(User.awesome)
@awesome_users.in_groups_of(2) #=> [[User, User], [User, User],...]
```

This commit delegates it to the decorated collection, which is likely what the developer is expecting:

``` ruby
@awesome_users = UserDecorator.decorate(User.awesome)
@awesome_users.in_groups_of(2) #=> [[UserDecorator, UserDecorator], [UserDecorator, UserDecorator],...]
```
