### PR TITLE
Fixes for Draper when used outside of a template

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -24,13 +24,13 @@ module Draper
 
     initializer "draper.extend_action_controller_base" do |app|
       ActiveSupport.on_load(:action_controller) do
-        Draper::System.setup(self)
+        Draper::System.setup_action_controller(self)
       end
     end
 
     initializer "draper.extend_action_mailer_base" do |app|
       ActiveSupport.on_load(:action_mailer) do
-        Draper::System.setup(self)
+        Draper::System.setup_action_mailer(self)
       end
     end
 

--- a/lib/draper/system.rb
+++ b/lib/draper/system.rb
@@ -1,10 +1,18 @@
 module Draper
   class System
-    def self.setup(component)
+    def self.setup_action_controller(component)
       component.class_eval do
         include Draper::ViewContext
-        extend  Draper::HelperSupport unless defined?(::ActionMailer) && self.is_a?(::ActionMailer::Base)
+        extend  Draper::HelperSupport
+        before_filter lambda {|controller|
+          Draper::ViewContext.current = nil
+          Draper::ViewContext.current_controller = controller
+        }
       end
+    end
+
+    def self.setup_action_mailer(component)
+      include Draper::ViewContext
     end
   end
 end

--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -1,11 +1,19 @@
 module Draper
   module ViewContext
+    def self.current_controller
+      Thread.current[:current_controller] || ApplicationController.new
+    end
+
+    def self.current_controller=(controller)
+      Thread.current[:current_controller] = controller
+    end
+
     def self.current
       Thread.current[:current_view_context] ||= build_view_context
     end
 
-    def self.current=(input)
-      Thread.current[:current_view_context] = input
+    def self.current=(context)
+      Thread.current[:current_view_context] = context
     end
 
     def view_context
@@ -17,10 +25,12 @@ module Draper
     private
 
     def self.build_view_context
-      ApplicationController.new.view_context.tap do |context|
-        context.controller.request ||= ActionController::TestRequest.new
-        context.request            ||= context.controller.request
-        context.params             ||= {}
+      current_controller.view_context.tap do |context|
+        if defined?(ActionController::TestRequest)
+          context.controller.request ||= ActionController::TestRequest.new
+          context.request            ||= context.controller.request
+          context.params             ||= {}
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require 'action_controller/test_case'
 
 module ActionController
   class Base
-    Draper::System.setup(self)
+    Draper::System.setup_action_controller(self)
   end
 end
 


### PR DESCRIPTION
Currently, when draper is used before `_render_template` is called, it uses a stubbed view_context built out of a new instance of `ApplicationController`. This means that it doesn't have the request parameters and such, which will obviously be used by `url_for` and named route helpers. This patch a) clears the current reference as a precaution, and b) assigns a reference to the current controller, which may be optionally used by Draper to create a new view_context if needed.

We don't simply assign a new view_context, as each invocation creates a new instance of `ActionView::Base`, so we want to delay creation of it for as long as possible, so that we give Rails the chance to create its instance if it's going to.
