### PR TITLE
Raise an error if a model is redecorated,

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -18,9 +18,11 @@ module Draper
     # @param [Object] instance to wrap
     # @param [Hash] options (optional)
     def initialize(input, options = {})
+      raise ArgumentError, "Can't decorate an object twice with the same decorator" if input.is_a?(self.class)
+
       input.inspect # forces evaluation of a lazy query from AR
       self.class.model_class = input.class if model_class.nil?
-      @model = input.kind_of?(Draper::Base) ? input.model : input
+      @model = input
       self.options = options
       self.extend Draper::ActiveModelSupport::Proxies
     end

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -45,9 +45,11 @@ describe Draper::Base do
       ProductDecorator.new(source).model_class.should == Product
     end
 
-    it "returns decorator if it's decorated model already" do
+    it "refuses to re-decorate an object" do
       product_decorator = ProductDecorator.new(source)
-      ProductDecorator.new(product_decorator).model.should be_instance_of Product
+      expect do
+        ProductDecorator.new(product_decorator)
+      end.to raise_error ArgumentError
     end
 
     it "handle plural-like words properly'" do


### PR DESCRIPTION
but only if the same decorator is used twice.

This prevent users from inadvertently re-decorating their objects, and forces them to fix their incorrect code before proceeding.

This removes the code from c945cce6f3147c805b4db73580c198016750ad60 that silently fixes the user's mistake. That code could lead to unexpected behavior if you're actually trying to decorate an object with multiple, distinct decorators.

I haven't updated the docs to reflect that Draper::Base.new and Draper::Base.decorate can now throw an ArgumentError.
