### PR TITLE
Kick lazy queries using to_a

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -18,7 +18,7 @@ module Draper
     # @param [Object] instance to wrap
     # @param [Hash] options (optional)
     def initialize(input, options = {})
-      input.inspect # forces evaluation of a lazy query from AR
+      input.to_a if input.respond_to?(:to_a) # forces evaluation of a lazy query from AR
       self.class.model_class = input.class if model_class.nil?
       @model = input.kind_of?(Draper::Base) ? input.model : input
       self.options = options


### PR DESCRIPTION
As discussed [here](https://github.com/drapergem/draper/commit/8ff68f3f96b2e0a56a7d1118c81326584633f50d#commitcomment-1838485), we can kick lazy AR queries using `to_a` instead of `inspect`, which allows models with custom lazy loading to still be lazy.
