### PR TITLE
Change :klass option to :class

### DIFF
--- a/lib/draper/decorated_enumerable_proxy.rb
+++ b/lib/draper/decorated_enumerable_proxy.rb
@@ -12,13 +12,13 @@ module Draper
     #
     # @param [Object] instances to wrap
     # @param [Hash] options (optional)
-    # @option options [Class] :klass The decorator class to use 
+    # @option options [Class] :class The decorator class to use
     #   for each item in the collection.
     # @option options all other options are passed to Decorator
     #   class for each item.
-              
+
     def self.decorate(collection, options = {})
-      new( collection, discern_class_from_my_class(options.delete(:klass)), options)
+      new( collection, discern_class_from_my_class(options.delete(:class)), options)
     end
     class << self
       alias_method :decorates, :decorate
@@ -72,12 +72,12 @@ module Draper
       @wrapped_collection
     end
     alias_method :to_source, :source
-    
+
     def helpers
       Draper::ViewContext.current
     end
     alias_method :h, :helpers
-    
+
     private
     def self.discern_class_from_my_class default_class
       return default_class if default_class

--- a/spec/draper/decorated_enumerable_proxy_spec.rb
+++ b/spec/draper/decorated_enumerable_proxy_spec.rb
@@ -26,8 +26,8 @@ describe Draper::DecoratedEnumerableProxy do
       EnumerableProxy.new([source], ProductDecorator).first.model.should == source
     end
 
-    it "decorates an empty array with the klass" do
-      EnumerableProxy.decorates([], klass: ProductDecorator).should be
+    it "decorates an empty array with the class" do
+      EnumerableProxy.decorates([], class: ProductDecorator).should be
     end
 
     it "discerns collection items decorator by the name of the decorator" do


### PR DESCRIPTION
[`DecoratedEnumerableProxy.decorate`](https://github.com/drapergem/draper/blob/master/lib/draper/decorated_enumerable_proxy.rb#L20) takes a `:klass` option to specify the decorator that should be used for its items. For consistency with [`Base.decorates`](https://github.com/drapergem/draper/blob/master/lib/draper/base.rb#L49) (and, in my opinion, aesthetics) it should be `:class`.

It's only on master and not in any released version, so the change shouldn't break too many apps.
