### PR TITLE
Fix incorrect method signature for I18n.localize proxy

### DIFF
--- a/lib/draper/base.rb
+++ b/lib/draper/base.rb
@@ -203,8 +203,8 @@ module Draper
     # Localize is something that's used quite often. Even though
     # it's available through helpers, that's annoying. Aliased
     # to `.l` for convenience.
-    def localize(str)
-      self.class.helpers.localize(str)
+    def localize(object, options = {})
+      self.class.helpers.localize(object, options)
     end
     alias :l :localize
 

--- a/spec/draper/base_spec.rb
+++ b/spec/draper/base_spec.rb
@@ -803,8 +803,9 @@ describe Draper::Base do
 
     it "is able to use l rather than helpers.l" do
       now = Time.now
-      decorator.helpers.instance_variable_get(:@helpers).should_receive(:localize).with(now)
-      decorator.l now
+      helper_proxy = decorator.helpers.instance_variable_get(:@helpers)
+      helper_proxy.should_receive(:localize).with(now, :format => :long)
+      decorator.l now, :format => :long
     end
 
     it "is able to access html_escape, a private method" do


### PR DESCRIPTION
`I18n.localize` [takes an object and an options hash](https://github.com/svenfuchs/i18n/blob/18ac0295091e5797c7d5228d974f5f077f98ef1d/lib/i18n.rb#L232-L238), Draper's proxy doesn't :wink:
