### PR TITLE
Simplify ActiveModelSupport?

### DIFF
--- a/lib/draper/active_model_support.rb
+++ b/lib/draper/active_model_support.rb
@@ -1,27 +1,11 @@
-module Draper::ActiveModelSupport
-  module Proxies
-    def self.extended(base)
-      # These methods (as keys) will be created only if the correspondent
-      # model responds to the method
-      proxies = [:to_param, :errors, :id]
+module Draper
+  module ActiveModelSupport
+    def to_model
+      self
+    end
 
-      proxies.each do |method_name|
-        if base.model.respond_to?(method_name)
-          base.singleton_class.class_eval do
-            if !base.class.instance_methods.include?(method_name) || base.class.instance_method(method_name).owner === Draper::Decorator
-              define_method(method_name) do |*args, &block|
-                model.send(method_name, *args, &block)
-              end
-            end
-          end
-        end
-      end
-
-      base.class_eval do
-        def to_model
-          self
-        end
-      end
+    def to_param
+      model.to_param
     end
   end
 end

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -1,7 +1,9 @@
+require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/array/extract_options'
+
 module Draper
   class Decorator
-    require 'active_support/core_ext/class/attribute'
-    require 'active_support/core_ext/array/extract_options'
+    include ActiveModelSupport
 
     class_attribute :denied, :allowed, :model_class
     attr_accessor :model, :options
@@ -22,7 +24,6 @@ module Draper
       self.class.model_class = input.class if model_class.nil?
       @model = input.kind_of?(Draper::Decorator) ? input.model : input
       self.options = options
-      self.extend Draper::ActiveModelSupport::Proxies
     end
 
     # Proxies to the class specified by `decorates` to automatically


### PR DESCRIPTION
I don't really get why [`ActiveModelSupport`](https://github.com/drapergem/draper/blob/master/lib/draper/active_model_support.rb) is so complicated.

If I understand correctly (and it's quite likely that I don't!), the point is to proxy `to_param`, `errors`, and `id` to the model, provided they are defined on the model but not on the decorator. But isn't this exactly what Draper does with any other method?!

Granted, `to_param` is defined on `Decorator` thanks to ActiveSupport, so it won't be delegated out of the box, but I think we can handle that case by always delegating it.

If I strip it back to basics, leaving just what you see in this pull request, all the specs stay green!

I must have gotten the wrong end of the stick, right?
