### PR TITLE
Memoize .helpers

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -196,7 +196,7 @@ module Draper
     #
     # @return [Object] proxy
     def helpers
-      HelpersWrapper.new self.class.helpers
+      @helpers ||= HelpersWrapper.new self.class.helpers
     end
     alias :h :helpers
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -28,6 +28,13 @@ describe Draper::Decorator do
     it "is aliased to .h" do
       subject.h.should == subject.helpers
     end
+
+    it "initializes the wrapper only once" do
+      helper_proxy = subject.helpers
+      helper_proxy.stub(:test_method) { "test_method" }
+      subject.helpers.test_method.should eq("test_method")
+      subject.helpers.test_method.should eq("test_method")
+    end
   end
 
   context("#helpers") do


### PR DESCRIPTION
In one of my apps, I have some specs that expect `.helpers` to be consistent  for the same instance of presenter. However, it seems that Draper instantiates new instance of `HelpersWrapper` everytime `helpers` is accessed

This does not create new instance of HelpersWrapper every time ".helpers" is accessed
