### PR TITLE
CollectionDecorator#find with a block proxies to undecorated collection

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -35,7 +35,7 @@ module Draper
 
     def find(ifnone_or_id = nil, &blk)
       if block_given?
-        source.find(ifnone_or_id, &blk)
+        decorated_collection.find(ifnone_or_id, &blk)
       else
         obj = decorated_collection.first
         return nil if obj.blank?

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -190,7 +190,7 @@ describe Draper::Decorator do
       before(:each){ subject.class_eval{ decorates_association :similar_products } }
       context "with a block" do
         it "delegates to #each" do
-          subject.similar_products.source.should_receive :find
+          subject.similar_products.decorated_collection.should_receive :find
           subject.similar_products.find {|p| p.title == "title" }
         end
       end


### PR DESCRIPTION
Given a `CollectionDecorator`, calling `#find` with a block returns an instance of the underlying model, undecorated. Trading `#find` for `#detect` works as `#each` is delegated to `decorated_collection` and therefore returns an instance of the decorated model.

https://github.com/drapergem/draper/blob/master/lib/draper/collection_decorator.rb#L38

Should `#find` delegate to `#decorated_collection` instead of `#source` when a block is provided? I can work up a pull request if this is the desired behavior.
