### PR TITLE
fix bug: unitialized constant NilClassDecorator no need to decorate an empty array anyways

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -60,7 +60,7 @@ module Draper
       define_method(association_symbol) do
         orig_association = model.send(association_symbol)
 
-        return orig_association if orig_association.nil?
+        return orig_association if orig_association.nil? || orig_association == []
         return decorated_associations[association_symbol] if decorated_associations[association_symbol]
 
         orig_association = orig_association.send(options[:scope]) if options[:scope]

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -198,6 +198,24 @@ describe Draper::Decorator do
       end
     end
 
+    context "when the association returns an empty collection" do
+      before(:each) do
+        subject.class_eval{ decorates_association :poro_similar_products }
+        source.stub(:poro_similar_products ){ [] }
+      end
+
+      context "when find_association_reflection returns nil" do
+        before(:each) do
+          subject.stub(:find_association_reflection => nil)
+        end
+
+        it "causes the association's method to return the empty collection" do
+          subject.poro_similar_products.should eq([])
+          subject.poro_similar_products.should be_instance_of(Array)
+        end
+      end
+    end
+
     context "#find" do
       before(:each){ subject.class_eval{ decorates_association :similar_products } }
       context "with a block" do


### PR DESCRIPTION
I'm using draper on a project that uses ActiveResource and ran into this problem. 
- would like to use implicit version of decorates_assocation
- this works fine because of this line https://github.com/drapergem/draper/blob/master/lib/draper/decorator.rb#L74
- but, if the association returns an empty array, it blows up

For example:

``` ruby
#given, Product has_many :attributes
# without draper involved
product.attributes 
# => []

# with draper, still no attributes
product = ProductDecorator.find(params[:id])
product.attributes
# => uninitialized constant NilClassDecorator
```

I think it would be better if draper just returned the empty array in this case.
