### PR TITLE
`rails generate` runs correctly under Rails 3.0.x

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -3,6 +3,7 @@ require 'rails/railtie'
 module ActiveModel
   class Railtie < Rails::Railtie
     generators do |app|
+      app ||= Rails.application # Rails 3.0.x does not yield `app` 
       Rails::Generators.configure!(app.config.generators)
       require "generators/resource_override"
     end


### PR DESCRIPTION
Fixing code so `rails genarate` runs correctly with draper installed under rails 3.0.x
