### PR TITLE
Simplify railtie

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -3,8 +3,8 @@ require 'rails/railtie'
 module ActiveModel
   class Railtie < Rails::Railtie
     generators do |app|
-      Rails::Generators.configure!(app.config.generators)
-      require "generators/resource_override"
+      Rails::Generators.configure! app.config.generators
+      require 'generators/resource_override'
     end
   end
 end
@@ -12,40 +12,33 @@ end
 module Draper
   class Railtie < Rails::Railtie
 
-    ##
-    # The `app/decorators` path is eager loaded
-    #
-    # This is the standard "Rails Way" to add paths from which constants
-    # can be loaded.
-    #
     config.after_initialize do |app|
-      app.config.paths.add 'app/decorators', :eager_load => true
+      app.config.paths.add 'app/decorators', eager_load: true
     end
 
-    initializer "draper.extend_action_controller_base" do |app|
-      ActiveSupport.on_load(:action_controller) do
-        Draper.setup_action_controller(self)
+    initializer "draper.setup_action_controller" do |app|
+      ActiveSupport.on_load :action_controller do
+        Draper.setup_action_controller self
       end
     end
 
-    initializer "draper.extend_action_mailer_base" do |app|
-      ActiveSupport.on_load(:action_mailer) do
-        Draper.setup_action_mailer(self)
+    initializer "draper.setup_action_mailer" do |app|
+      ActiveSupport.on_load :action_mailer do
+        Draper.setup_action_mailer self
       end
     end
 
-    initializer "draper.extend_active_record_base" do |app|
-      ActiveSupport.on_load(:active_record) do
-        Draper.setup_active_record(self)
+    initializer "draper.setup_active_record" do |app|
+      ActiveSupport.on_load :active_record do
+        Draper.setup_active_record self
       end
     end
 
     console do
       require 'action_controller/test_case'
       ApplicationController.new.view_context
-      Draper::ViewContext.current.controller.request ||= ActionController::TestRequest.new
-      Draper::ViewContext.current.request            ||= Draper::ViewContext.current.controller.request
-      Draper::ViewContext.current.params             ||= {}
+      Draper::ViewContext.build_view_context
     end
+
   end
 end

--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -1,5 +1,11 @@
 module Draper
   module ViewContext
+    def view_context
+      super.tap do |context|
+        Draper::ViewContext.current = context
+      end
+    end
+
     def self.current_controller
       Thread.current[:current_controller] || ApplicationController.new
     end
@@ -15,14 +21,6 @@ module Draper
     def self.current=(context)
       Thread.current[:current_view_context] = context
     end
-
-    def view_context
-      super.tap do |context|
-        Draper::ViewContext.current = context
-      end
-    end
-
-    private
 
     def self.build_view_context
       current_controller.view_context.tap do |context|


### PR DESCRIPTION
We can use the `build_view_context` method in the railtie to keep it DRY.
