### PR TITLE
Include ActiveModel::Serialization in Draper::Decorator.

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -27,7 +27,7 @@ module Draper
       source.to_a if source.respond_to?(:to_a) # forces evaluation of a lazy query from AR
       @source = source
       @options = options
-      handle_multiple_decoration if source.is_a?(Draper::Decorator)      
+      handle_multiple_decoration if source.is_a?(Draper::Decorator)
     end
 
     class << self

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -11,12 +11,6 @@ describe Draper::Decorator do
       subject.source.should be source
     end
 
-    if defined?(ActiveModel::Serialization)
-      it "includes ActiveModel::Serialization if present" do
-        subject.should respond_to(:serializable_hash)
-      end
-    end
-
     it "stores options" do
       decorator = decorator_class.new(source, some: "options")
       decorator.options.should == {some: "options"}
@@ -485,6 +479,14 @@ describe Draper::Decorator do
           subject.finder_class.should be Namespace::Product
         end
       end
+    end
+  end
+
+  describe "#serializable_hash" do
+    let(:decorator_class) { ProductDecorator }
+
+    it "serializes overridden attributes" do
+      subject.serializable_hash[:overridable].should be :overridden
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'action_controller/test_case'
 
 Bundler.require
 
+require './spec/support/active_model'
 require './spec/support/active_record'
 require './spec/support/action_controller'
 

--- a/spec/support/active_model.rb
+++ b/spec/support/active_model.rb
@@ -1,0 +1,7 @@
+module ActiveModel
+  module Serialization
+    def serializable_hash
+      {overridable: send(:overridable)}
+    end
+  end
+end

--- a/spec/support/models/product.rb
+++ b/spec/support/models/product.rb
@@ -1,5 +1,6 @@
 class Product < ActiveRecord::Base
   include Draper::Decoratable
+  include ActiveModel::Serialization
 
   def self.find_by_name(name)
     @@dummy ||= Product.new


### PR DESCRIPTION
Include `ActiveModel::Serialization` if defined to play nice with `ActiveModel::Serializer`

There might be better ways to spec it?
