### PR TITLE
#to_model should alias to source, not self

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -168,7 +168,7 @@ module Draper
 
     # For ActiveModel compatibilty
     def to_model
-      self
+      source
     end
 
     # For ActiveModel compatibility

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -207,7 +207,7 @@ describe Draper::Decorator do
 
   describe "#to_model" do
     it "returns the decorator" do
-      subject.to_model.should be subject
+      subject.to_model.should be source
     end
   end
 


### PR DESCRIPTION
Somewhere along the line, `#to_model` was broken to point to the decorator instance, rather than the decorated model. This breaks a whole heap of things, mostly having to do with URL generation when you pass a decorated model to `url_for`. This patch restores the old stable functionality.
