### PR TITLE
Change documentation to say "decorate_collection"

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -201,7 +201,7 @@ ArticleDecorator.new(Article.find(params[:id]))
 
 ```ruby
 ArticleDecorator.decorate(Article.first) # Returns one instance of ArticleDecorator
-ArticleDecorator.decorate(Article.all)   # Returns an enumeration proxy of ArticleDecorator instances
+ArticleDecorator.decorate_collection(Article.all)   # Returns CollectionDecorator of ArticleDecorator
 ```
 
 ### In Your Views


### PR DESCRIPTION
Maybe there's actually a bug, but I can't see where it would make collections in `.decorate` a CollectionDecorator.
