### PR TITLE
Delay require for test helper files until railtie after initialize.

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -14,11 +14,6 @@ require 'draper/view_context'
 require 'draper/collection_decorator'
 require 'draper/railtie' if defined?(Rails)
 
-# Test Support
-require 'draper/test/rspec_integration'     if defined?(RSpec) and RSpec.respond_to?(:configure)
-require 'draper/test/minitest_integration'  if defined?(MiniTest::Rails)
-require 'draper/test/test_unit_integration'
-
 module Draper
   def self.setup_action_controller(base)
     base.class_eval do

--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -16,6 +16,11 @@ module Draper
 
     config.after_initialize do |app|
       app.config.paths.add 'app/decorators', eager_load: true
+
+      # Test Support
+      require 'draper/test/rspec_integration' if defined?(RSpec) and RSpec.respond_to?(:configure)
+      require 'draper/test/minitest_integration'  if defined?(MiniTest::Rails)
+      require 'draper/test/test_unit_integration'
     end
 
     initializer "draper.setup_action_controller" do |app|


### PR DESCRIPTION
Delay require for test helper files so that they are loaded correctly when running rspec under something like Guard::Spin.
