### PR TITLE
Add a helper method sign_in for devise in decorator specs.

### DIFF
--- a/lib/draper/test/rspec_integration.rb
+++ b/lib/draper/test/rspec_integration.rb
@@ -3,6 +3,39 @@ module Draper
     extend ActiveSupport::Concern
     included { metadata[:type] = :decorator }
   end
+
+  module DeviseHelper
+    def sign_in(user)
+      warden.stub :authenticate! => user
+      controller.stub :current_user => user
+      user
+    end
+
+    private
+
+    def request
+      @request ||= ::ActionDispatch::TestRequest.new
+    end
+
+    def controller
+      return @controller if @controller
+      @controller = ApplicationController.new
+      @controller.request = request
+      ::Draper::ViewContext.current = @controller.view_context
+      @controller
+    end
+
+    # taken from Devise's helper but uses the request method instead of @request
+    #   and we don't really need the rest of their helper
+    def warden
+      @warden ||= begin
+        manager = Warden::Manager.new(nil) do |config|
+          config.merge! Devise.warden_config
+        end
+        request.env['warden'] = Warden::Proxy.new(request.env, manager)
+      end
+    end
+  end
 end
 
 RSpec.configure do |config|
@@ -11,7 +44,11 @@ RSpec.configure do |config|
     :file_path => /spec[\\\/]decorators/
   }
 
+  if defined?(Devise)
+    config.include Draper::DeviseHelper, :type => :decorator
+  end
 end
+
 module Draper
   module RSpec
     class Railtie < Rails::Railtie


### PR DESCRIPTION
This allows `current_user` to be set for Devise in decorator tests in RSpec. See #363 for details.
