### PR TITLE
Use `self == other.source` in Decoratable#==

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -22,7 +22,7 @@ module Draper::Decoratable
   end
 
   def ==(other)
-    super || (other.respond_to?(:source) && super(other.source))
+    super || (other.respond_to?(:source) && self == other.source)
   end
 
   module ClassMethods

--- a/spec/dummy/spec/models/post_spec.rb
+++ b/spec/dummy/spec/models/post_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Post do
+  describe "#==" do
+    before { Post.create }
+    subject { Post.first }
+
+    it "is true for other instances' decorators" do
+      other = Post.first
+      subject.should_not be other
+      (subject == other.decorate).should be_true
+    end
+  end
+end


### PR DESCRIPTION
Apparently AR::Base does something tricky with #== which causes `super(other.source)` to break when comparing a model to a decorator that wraps a different instance of the same model. Weird.

I added an integration spec for that case.

Closes #391.
