### PR TITLE
Infer collection decorators for decorated associations

### DIFF
--- a/lib/draper/decorated_association.rb
+++ b/lib/draper/decorated_association.rb
@@ -53,11 +53,13 @@ module Draper
       if decorator_class
         decorator_class.method(:decorate)
       else
-        ->(item, options) { item.decorate(options) }
+        inferred_decorator
       end
     end
 
     def collection_decorator
+      return inferred_decorator if decorator_class.nil? && undecorated.respond_to?(:decorate)
+
       klass = decorator_class || Draper::CollectionDecorator
 
       if klass.respond_to?(:decorate_collection)
@@ -65,6 +67,10 @@ module Draper
       else
         klass.method(:decorate)
       end
+    end
+
+    def inferred_decorator
+      ->(item, options) { item.decorate(options) }
     end
 
   end

--- a/spec/draper/decorated_association_spec.rb
+++ b/spec/draper/decorated_association_spec.rb
@@ -74,9 +74,18 @@ describe Draper::DecoratedAssociation do
       end
 
       context "when :with option was not given" do
-        it "uses a CollectionDecorator of inferred decorators" do
-          Draper::CollectionDecorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated_collection)
-          decorated_association.call.should be :decorated_collection
+        context "when the collection responds to decorate" do
+          it "calls decorate on the collection" do
+            associated.should_receive(:decorate).with(expected_options).and_return(:decorated_collection)
+            decorated_association.call.should be :decorated_collection
+          end
+        end
+
+        context "when the collection does not respond to decorate" do
+          it "uses a CollectionDecorator of inferred decorators" do
+            Draper::CollectionDecorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated_collection)
+            decorated_association.call.should be :decorated_collection
+          end
         end
       end
     end


### PR DESCRIPTION
This change means that, given

``` ruby
ArticleDecorator.decorates_association :comments

article.decorate.comments
article.comments.decorate
```

both return a `CommentsDecorator`, if it exists. Currently, as @tovodeverett pointed out on #408, the former returns a vanilla `CollectionDecorator` while the latter correctly infers the custom `CommentsDecorator`.
