### PR TITLE
Prevent calls to `scoped` on decorated associations

### DIFF
--- a/lib/draper/decorated_association.rb
+++ b/lib/draper/decorated_association.rb
@@ -25,7 +25,7 @@ module Draper
 
     private
 
-    attr_reader :owner, :association, :decorator_class, :scope
+    attr_reader :owner, :association, :scope
 
     def source
       owner.source
@@ -49,17 +49,10 @@ module Draper
 
     def decorator
       return collection_decorator if collection?
-
-      if decorator_class
-        decorator_class.method(:decorate)
-      else
-        inferred_decorator
-      end
+      decorator_class.method(:decorate)
     end
 
     def collection_decorator
-      return inferred_decorator if decorator_class.nil? && undecorated.respond_to?(:decorate)
-
       klass = decorator_class || Draper::CollectionDecorator
 
       if klass.respond_to?(:decorate_collection)
@@ -69,8 +62,12 @@ module Draper
       end
     end
 
-    def inferred_decorator
-      ->(item, options) { item.decorate(options) }
+    def decorator_class
+      @decorator_class || inferred_decorator_class
+    end
+
+    def inferred_decorator_class
+      undecorated.decorator_class if undecorated.respond_to?(:decorator_class)
     end
 
   end

--- a/spec/draper/decorated_association_spec.rb
+++ b/spec/draper/decorated_association_spec.rb
@@ -31,10 +31,10 @@ describe Draper::DecoratedAssociation do
 
     context "for a singular association" do
       let(:associated) { Product.new }
+      let(:decorator) { SpecificProductDecorator }
 
       context "when :with option was given" do
         let(:options) { {with: decorator} }
-        let(:decorator) { SpecificProductDecorator }
 
         it "uses the specified decorator" do
           decorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated)
@@ -44,7 +44,8 @@ describe Draper::DecoratedAssociation do
 
       context "when :with option was not given" do
         it "infers the decorator" do
-          associated.should_receive(:decorate).with(expected_options).and_return(:decorated)
+          associated.stub(:decorator_class).and_return(decorator)
+          decorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated)
           decorated_association.call.should be :decorated
         end
       end
@@ -52,10 +53,10 @@ describe Draper::DecoratedAssociation do
 
     context "for a collection association" do
       let(:associated) { [Product.new, Widget.new] }
+      let(:collection_decorator) { ProductsDecorator }
 
       context "when :with option is a collection decorator" do
         let(:options) { {with: collection_decorator} }
-        let(:collection_decorator) { ProductsDecorator }
 
         it "uses the specified decorator" do
           collection_decorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated_collection)
@@ -74,14 +75,15 @@ describe Draper::DecoratedAssociation do
       end
 
       context "when :with option was not given" do
-        context "when the collection responds to decorate" do
-          it "calls decorate on the collection" do
-            associated.should_receive(:decorate).with(expected_options).and_return(:decorated_collection)
+        context "when the collection is decoratable" do
+          it "infers the decorator" do
+            associated.stub(:decorator_class).and_return(collection_decorator)
+            collection_decorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated_collection)
             decorated_association.call.should be :decorated_collection
           end
         end
 
-        context "when the collection does not respond to decorate" do
+        context "when the collection is not decoratable" do
           it "uses a CollectionDecorator of inferred decorators" do
             Draper::CollectionDecorator.should_receive(:decorate).with(associated, expected_options).and_return(:decorated_collection)
             decorated_association.call.should be :decorated_collection


### PR DESCRIPTION
Calling `parent.children.decorate` breaks `inverse_of` support, due to the call to `scoped` in `Decoratable.decorate`.

This fix changes decorated associations to do something equivalent to 

``` ruby
parent.children.decorator_class.decorate_collection(parent.children)
```

which does the same thing as `parent.children.decorate` but without calling `scoped`, and thus preserves the `inverse_of` link.

Closes #412.
