### PR TITLE
Add `helper` method to tests

### DIFF
--- a/lib/draper/test/devise_helper.rb
+++ b/lib/draper/test/devise_helper.rb
@@ -1,0 +1,34 @@
+module Draper
+  module DeviseHelper
+    def sign_in(user)
+      warden.stub :authenticate! => user
+      controller.stub :current_user => user
+      user
+    end
+
+    private
+
+    def request
+      @request ||= ::ActionDispatch::TestRequest.new
+    end
+
+    def controller
+      return @controller if @controller
+      @controller = ApplicationController.new
+      @controller.request = request
+      ::Draper::ViewContext.current = @controller.view_context
+      @controller
+    end
+
+    # taken from Devise's helper but uses the request method instead of @request
+    #   and we don't really need the rest of their helper
+    def warden
+      @warden ||= begin
+        manager = Warden::Manager.new(nil) do |config|
+          config.merge! Devise.warden_config
+        end
+        request.env['warden'] = Warden::Proxy.new(request.env, manager)
+      end
+    end
+  end
+end

--- a/lib/draper/test/minitest_integration.rb
+++ b/lib/draper/test/minitest_integration.rb
@@ -1,7 +1,31 @@
-class MiniTest::Rails::ActiveSupport::TestCase
-  # Use AS::TestCase for the base class when describing a decorator
-  register_spec_type(self) do |desc|
-    desc < Draper::Decorator if desc.is_a?(Class)
+require 'minitest/rails/active_support'
+
+module Draper
+  module MiniTest
+
+    class DecoratorTestCase < ::MiniTest::Rails::ActiveSupport::TestCase
+      include Draper::ViewHelpers::ClassMethods
+      alias_method :helper, :helpers
+
+      register_spec_type(self) do |desc|
+        desc < Draper::Decorator if desc.is_a?(Class)
+      end
+      register_spec_type(/Decorator( ?Test)?\z/i, self)
+    end
+
+    class Railtie < Rails::Railtie
+      config.after_initialize do |app|
+        if defined?(Capybara)
+          require 'capybara/rspec/matchers'
+          DecoratorTestCase.send :include, Capybara::RSpecMatchers
+        end
+
+        if defined?(Devise)
+          require 'draper/test/devise_helper'
+          DecoratorTestCase.send :include, Draper::DeviseHelper
+        end
+      end
+    end
   end
-  register_spec_type(/Decorator( ?Test)?\z/i, self)
+
 end

--- a/lib/draper/test/rspec_integration.rb
+++ b/lib/draper/test/rspec_integration.rb
@@ -1,67 +1,37 @@
 module Draper
-  module DecoratorExampleGroup
-    extend ActiveSupport::Concern
-    included { metadata[:type] = :decorator }
-  end
-
-  module DeviseHelper
-    def sign_in(user)
-      warden.stub :authenticate! => user
-      controller.stub :current_user => user
-      user
-    end
-
-    private
-
-    def request
-      @request ||= ::ActionDispatch::TestRequest.new
-    end
-
-    def controller
-      return @controller if @controller
-      @controller = ApplicationController.new
-      @controller.request = request
-      ::Draper::ViewContext.current = @controller.view_context
-      @controller
-    end
-
-    # taken from Devise's helper but uses the request method instead of @request
-    #   and we don't really need the rest of their helper
-    def warden
-      @warden ||= begin
-        manager = Warden::Manager.new(nil) do |config|
-          config.merge! Devise.warden_config
-        end
-        request.env['warden'] = Warden::Proxy.new(request.env, manager)
-      end
-    end
-  end
-end
-
-RSpec.configure do |config|
-  # Automatically tag specs in specs/decorators as type: :decorator
-  config.include Draper::DecoratorExampleGroup, :type => :decorator, :example_group => {
-    :file_path => /spec[\\\/]decorators/
-  }
-
-  if defined?(Devise)
-    config.include Draper::DeviseHelper, :type => :decorator
-  end
-end
-
-module Draper
   module RSpec
+
+    module DecoratorExampleGroup
+      extend ActiveSupport::Concern
+      included { metadata[:type] = :decorator }
+
+      include Draper::ViewHelpers::ClassMethods
+      alias_method :helper, :helpers
+    end
+
+    ::RSpec.configure do |config|
+      # Automatically tag specs in specs/decorators as type: :decorator
+      config.include DecoratorExampleGroup, :type => :decorator, :example_group => {
+        :file_path => %r{spec/decorators}
+      }
+    end
+
     class Railtie < Rails::Railtie
       config.after_initialize do |app|
-        if defined?(Capybara)
-          require 'capybara/rspec/matchers'
+        ::RSpec.configure do |rspec|
+          if defined?(Capybara)
+            require 'capybara/rspec/matchers'
+            rspec.include Capybara::RSpecMatchers, :type => :decorator
+          end
 
-          ::RSpec.configure do |config|
-            config.include Capybara::RSpecMatchers, :type => :decorator
+          if defined?(Devise)
+            require 'draper/test/devise_helper'
+            rspec.include Draper::DeviseHelper, :type => :decorator
           end
         end
       end
     end
+
   end
 end
 

--- a/spec/minitest-rails/spec_type_spec.rb
+++ b/spec/minitest-rails/spec_type_spec.rb
@@ -6,58 +6,58 @@ describe "minitest-rails spec_type Lookup Integration" do
   context "ProductDecorator" do
     it "resolves constants" do
       klass = MiniTest::Spec.spec_type(ProductDecorator)
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
 
     it "resolves strings" do
       klass = MiniTest::Spec.spec_type("ProductDecorator")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
   end
 
   context "WidgetDecorator" do
     it "resolves constants" do
       klass = MiniTest::Spec.spec_type(WidgetDecorator)
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
 
     it "resolves strings" do
       klass = MiniTest::Spec.spec_type("WidgetDecorator")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
   end
 
   context "decorator strings" do
     it "resolves DoesNotExistDecorator" do
       klass = MiniTest::Spec.spec_type("DoesNotExistDecorator")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
 
     it "resolves DoesNotExistDecoratorTest" do
       klass = MiniTest::Spec.spec_type("DoesNotExistDecoratorTest")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
 
     it "resolves Does Not Exist Decorator" do
       klass = MiniTest::Spec.spec_type("Does Not Exist Decorator")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
 
     it "resolves Does Not Exist Decorator Test" do
       klass = MiniTest::Spec.spec_type("Does Not Exist Decorator Test")
-      klass.should == MiniTest::Rails::ActiveSupport::TestCase
+      klass.should be Draper::MiniTest::DecoratorTestCase
     end
   end
 
   context "non-decorators" do
     it "doesn't resolve constants" do
       klass = MiniTest::Spec.spec_type(Draper::HelperSupport)
-      klass.should == MiniTest::Spec
+      klass.should be MiniTest::Spec
     end
 
     it "doesn't resolve strings" do
       klass = MiniTest::Spec.spec_type("Nothing to see here...")
-      klass.should == MiniTest::Spec
+      klass.should be MiniTest::Spec
     end
   end
 end


### PR DESCRIPTION
As suggested on #411. I took the opportunity to get the same features into the MiniTest integration as are in the RSpec version.
