### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -1,10 +1,11 @@
 require 'active_support/core_ext/array/extract_options'
+require 'active_model/serialization'
 
 module Draper
   class Decorator
     include Draper::ViewHelpers
     extend Draper::Delegation
-    include ActiveModel::Serialization if defined?(ActiveModel::Serialization)
+    include ActiveModel::Serialization
 
     # @return the object being decorated.
     attr_reader :source

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'


### PR DESCRIPTION
It seems `ActiveModel::Serialization` is not required by default in Rails 4 but since it's present in 3.0+ I think it's ok to just require it ourselves instead of checking if it is defined.

After this change all the unit specs pass on Rails master.

**Update**: should do the integration specs now too, once GitHub starts playing nice with Travis again.
