### PR TITLE
add license information to the gemspec

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'minitest-rails', '~> 0.2'
   s.add_development_dependency 'capybara'
+  s.license = "MIT"
 end


### PR DESCRIPTION
so that it can be used from rubygems.org API
