### PR TITLE
restrict inclusion of test dependencies to test environment only

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -17,7 +17,7 @@ module Draper
     config.after_initialize do |app|
       app.config.paths.add 'app/decorators', eager_load: true
 
-      unless Rails.env.production?
+      if Rails.env.test?
         require 'draper/test_case'
         require 'draper/test/rspec_integration' if defined?(RSpec) and RSpec.respond_to?(:configure)
         require 'draper/test/minitest_integration' if defined?(MiniTest::Rails)


### PR DESCRIPTION
We were having some issues in our build pipeline once our Draper-enabled code reached our first production-like environment as the test dependencies weren't available to it.. We have a  number of similar prod-like environments (which use varying Rails.env values), and were wondering what your thoughts are on this change - which worked for us..
