### PR TITLE
Add gem version badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Draper: View Models for Rails
 
+[![Gem Version](https://badge.fury.io/rb/draper.png)](http://badge.fury.io/rb/draper)
 [![TravisCI Build Status](https://secure.travis-ci.org/drapergem/draper.png?branch=master)](http://travis-ci.org/drapergem/draper)
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/drapergem/draper)
 


### PR DESCRIPTION
Can be pretty useful for those who do not use `bundle outdated` but visit README from time to time (like me).
