### PR TITLE
Add respond_to_missing?

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -12,16 +12,8 @@ module Draper
 
     # Checks if the decorator responds to an instance method, or is able to
     # proxy it to the source object.
-    def respond_to?(method, include_private = false)
+    def respond_to_missing?(method, include_private = false)
       super || delegatable?(method)
-    end
-
-    if RUBY_VERSION >= "1.9.2"
-      # respond_to_missing? functions identically to respond_to?, but enables
-      # reflection with Object#method.
-      def respond_to_missing?(method, include_private = false)
-        super || delegatable?(method)
-      end
     end
 
     # @private
@@ -39,16 +31,8 @@ module Draper
 
       # Checks if the decorator responds to a class method, or is able to proxy
       # it to the source class.
-      def respond_to?(method, include_private = false)
+      def respond_to_missing?(method, include_private = false)
         super || delegatable?(method)
-      end
-
-      if RUBY_VERSION >= "1.9.2"
-        # respond_to_missing? functions identically to respond_to?, but enables
-        # reflection with Object.method.
-        def respond_to_missing?(method, include_private = false)
-          super || delegatable?(method)
-        end
       end
 
       # @private

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -564,24 +564,22 @@ module Draper
         end
       end
 
-      if RUBY_VERSION >= "1.9.2"
-        describe "#respond_to_missing?" do
-          it "allows #method to be called on delegated methods" do
-            source = Class.new{def hello_world; end}.new
-            decorator = Decorator.new(source)
+      describe "#respond_to_missing?" do
+        it "allows #method to be called on delegated methods" do
+          source = Class.new{def hello_world; end}.new
+          decorator = Decorator.new(source)
 
-            expect { decorator.method(:hello_world) }.not_to raise_error NameError
-            expect(decorator.method(:hello_world)).not_to be_nil
-          end
+          expect { decorator.method(:hello_world) }.not_to raise_error NameError
+          expect(decorator.method(:hello_world)).not_to be_nil
         end
+      end
 
-        describe ".respond_to_missing?" do
-          it "allows .method to be called on delegated class methods" do
-            Decorator.stub source_class: double(hello_world: :delegated)
+      describe ".respond_to_missing?" do
+        it "allows .method to be called on delegated class methods" do
+          Decorator.stub source_class: double(hello_world: :delegated)
 
-            expect { Decorator.method(:hello_world) }.not_to raise_error NameError
-            expect(Decorator.method(:hello_world)).not_to be_nil
-          end
+          expect { Decorator.method(:hello_world) }.not_to raise_error NameError
+          expect(Decorator.method(:hello_world)).not_to be_nil
         end
       end
     end


### PR DESCRIPTION
Hello! This probably doesn't affect a huge number of people, but I ran across a problem in a project I'm working on that was caused by a Draper decorator object not returning a delegated method when I queried it using #method. I patched it by including respond_to_missing? methods for both instances and classes. Since respond_to_missing? seems only to have appeared in Ruby 1.9.2, I guarded the code against evaluating in earlier versions of Ruby.
