### PR TITLE
Fix decorator collections STI trouble

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -49,11 +49,7 @@ module Draper
     end
 
     def to_s
-      klass = begin
-        decorator_class
-      rescue Draper::UninferrableDecoratorError
-        "inferred decorators"
-      end
+      klass = decorator_class || "inferred decorators"
 
       "#<#{self.class.name} of #{klass} for #{source.inspect}>"
     end
@@ -67,7 +63,7 @@ module Draper
     #   {#initialize} or as inferred from the collection decorator class (e.g.
     #   `ProductsDecorator` maps to `ProductDecorator`).
     def decorator_class
-      @decorator_class ||= self.class.inferred_decorator_class
+      @decorator_class
     end
 
     # @return [true]
@@ -87,24 +83,10 @@ module Draper
 
     private
 
-    def self.inferred_decorator_class
-      decorator_name = "#{name.chomp("Decorator").singularize}Decorator"
-      decorator_uninferrable if decorator_name == name
-
-      decorator_name.constantize
-
-    rescue NameError
-      decorator_uninferrable
-    end
-
-    def self.decorator_uninferrable
-      raise Draper::UninferrableDecoratorError.new(self)
-    end
-
     def item_decorator
-      @item_decorator ||= begin
+      if decorator_class
         decorator_class.method(:decorate)
-      rescue Draper::UninferrableDecoratorError
+      else
         ->(item, options) { item.decorate(options) }
       end
     end


### PR DESCRIPTION
Decorating STI collection cause trouble with inferred decorator class:
class Movie 
end

class Film < Movie
end

class Serial < Movie
end

class MovieDecorator < Draper::Decorator
  delegate_all
end

class FilmDecorator < MovieDecorator
end

class SerialDecorator < MovieDecorator
end

class MoviesDecorator < Draper::CollectionDecorator
  delegate :current_page, :total_pages, :limit_value
end

movies = Movie.page.decorate # MoviesDecorator of [#Film:..., #Serial:...]
movies.first.class # MovieDecorator instead of FilmDecorator
