### PR TITLE
Define `before_remove_const` callback

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -39,6 +39,12 @@ module Draper
       def delegatable?(method)
         source_class? && source_class.respond_to?(method)
       end
+
+      # @private
+      # Avoids reloading the model class when ActiveSupport clears autoloaded
+      # dependencies in development mode.
+      def before_remove_const
+      end
     end
 
     included do


### PR DESCRIPTION
Avoids reloading the model class when ActiveSupport clears autoloaded dependencies in development mode.

Closes #465.
