### PR TITLE
Accept a lambda for context in factory

### DIFF
--- a/lib/draper/decorated_association.rb
+++ b/lib/draper/decorated_association.rb
@@ -9,19 +9,15 @@ module Draper
       @association = association
 
       @scope = options[:scope]
-      @context = options.fetch(:context, ->(context){ context })
 
-      @factory = Draper::Factory.new(options.slice(:with))
+      decorator_class = options[:with]
+      context = options.fetch(:context, ->(context){ context })
+      @factory = Draper::Factory.new(with: decorator_class, context: context)
     end
 
     def call
       decorate unless defined?(@decorated)
       @decorated
-    end
-
-    def context
-      return @context.call(owner.context) if @context.respond_to?(:call)
-      @context
     end
 
     private
@@ -32,7 +28,7 @@ module Draper
       associated = owner.source.send(association)
       associated = associated.send(scope) if scope
 
-      @decorated = factory.decorate(associated, context: context)
+      @decorated = factory.decorate(associated, context_args: owner.context)
     end
 
   end

--- a/lib/draper/decorates_assigned.rb
+++ b/lib/draper/decorates_assigned.rb
@@ -19,7 +19,12 @@ module Draper
     #   @param [Symbols*] variables
     #     names of the instance variables to decorate (without the `@`).
     #   @param [Hash] options
-    #     see {Factory#initialize}
+    #   @option options [Decorator, CollectionDecorator] :with (nil)
+    #     decorator class to use. If nil, it is inferred from the instance
+    #     variable.
+    #   @option options [Hash, #call] :context
+    #     extra data to be stored in the decorator. If a Proc is given, it will
+    #     be passed the controller and should return a new context hash.
     def decorates_assigned(*variables)
       factory = Draper::Factory.new(variables.extract_options!)
 
@@ -29,7 +34,7 @@ module Draper
 
         define_method variable do
           return instance_variable_get(decorated) if instance_variable_defined?(decorated)
-          instance_variable_set decorated, factory.decorate(instance_variable_get(undecorated))
+          instance_variable_set decorated, factory.decorate(instance_variable_get(undecorated), context_args: self)
         end
 
         helper_method variable

--- a/lib/draper/factory.rb
+++ b/lib/draper/factory.rb
@@ -2,11 +2,13 @@ module Draper
   class Factory
     # Creates a decorator factory.
     #
-    # @option options [Decorator,CollectionDecorator] :with (nil)
+    # @option options [Decorator, CollectionDecorator] :with (nil)
     #   decorator class to use. If nil, it is inferred from the object
     #   passed to {#decorate}.
-    # @option options [Hash] context
-    #   extra data to be stored in created decorators.
+    # @option options [Hash, #call] context
+    #   extra data to be stored in created decorators. If a proc is given, it
+    #   will be called each time {#decorate} is called and its return value
+    #   will be used as the context.
     def initialize(options = {})
       options.assert_valid_keys(:with, :context)
       @decorator_class = options.delete(:with)
@@ -21,6 +23,8 @@ module Draper
     # @option options [Hash] context
     #   extra data to be stored in the decorator. Overrides any context passed
     #   to the constructor.
+    # @option options [Object, Array] context_args (nil)
+    #   argument(s) to be passed to the context proc.
     # @return [Decorator, CollectionDecorator] the decorated object.
     def decorate(source, options = {})
       return nil if source.nil?
@@ -31,6 +35,7 @@ module Draper
 
     attr_reader :decorator_class, :default_options
 
+    # @private
     class Worker
       def initialize(decorator_class, source)
         @decorator_class = decorator_class
@@ -38,6 +43,7 @@ module Draper
       end
 
       def call(options)
+        update_context options
         decorator.call(source, options)
       end
 
@@ -70,6 +76,11 @@ module Draper
 
       def source_decorator_class
         source.decorator_class if source.respond_to?(:decorator_class)
+      end
+
+      def update_context(options)
+        args = options.delete(:context_args)
+        options[:context] = options[:context].call(*args) if options[:context].respond_to?(:call)
       end
     end
   end

--- a/spec/draper/decorates_assigned_spec.rb
+++ b/spec/draper/decorates_assigned_spec.rb
@@ -49,7 +49,7 @@ module Draper
           controller = controller_class.new
           controller.instance_variable_set "@article", source
 
-          factory.should_receive(:decorate).with(source).and_return(:decorated)
+          factory.should_receive(:decorate).with(source, context_args: controller).and_return(:decorated)
           expect(controller.article).to be :decorated
         end
 

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -104,6 +104,48 @@ module Draper
         decorator.should_receive(:call).with(source, options).and_return(:decorated)
         expect(worker.call(options)).to be :decorated
       end
+
+      context "when the :context option is callable" do
+        it "calls it" do
+          worker = Factory::Worker.new(double, double)
+          decorator = ->(*){}
+          worker.stub decorator: decorator
+          context = {foo: "bar"}
+
+          decorator.should_receive(:call).with(anything(), context: context)
+          worker.call(context: ->{ context })
+        end
+
+        it "receives arguments from the :context_args option" do
+          worker = Factory::Worker.new(double, double)
+          worker.stub decorator: ->(*){}
+          context = ->{}
+
+          context.should_receive(:call).with(:foo, :bar)
+          worker.call(context: context, context_args: [:foo, :bar])
+        end
+      end
+
+      context "when the :context option is not callable" do
+        it "doesn't call it" do
+          worker = Factory::Worker.new(double, double)
+          decorator = ->(*){}
+          worker.stub decorator: decorator
+          context = {foo: "bar"}
+
+          decorator.should_receive(:call).with(anything(), context: context)
+          worker.call(context: context)
+        end
+      end
+
+      it "does not pass the :context_args option to the decorator" do
+        worker = Factory::Worker.new(double, double)
+        decorator = ->(*){}
+        worker.stub decorator: decorator
+
+        decorator.should_receive(:call).with(anything(), foo: "bar")
+        worker.call(foo: "bar", context_args: [])
+      end
     end
 
     describe "#decorator" do


### PR DESCRIPTION
Like `decorates_association`, you can now pass a context lambda to `decorates_assigned`, which receives the current controller instance and returns a hash:

``` ruby
class ArticleController < ApplicationController
  decorates_assigned :article, context: ->(controller){ {user: controller.current_user} }
end
```

The actual calling of the lambda has been extracted to the Factory·

Closes #467
