### PR TITLE
Wrap context_args to avoid splatting hashes

### DIFF
--- a/lib/draper/factory.rb
+++ b/lib/draper/factory.rb
@@ -80,7 +80,7 @@ module Draper
 
       def update_context(options)
         args = options.delete(:context_args)
-        options[:context] = options[:context].call(*args) if options[:context].respond_to?(:call)
+        options[:context] = options[:context].call(*Array.wrap(args)) if options[:context].respond_to?(:call)
       end
     end
   end

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -124,6 +124,16 @@ module Draper
           context.should_receive(:call).with(:foo, :bar)
           worker.call(context: context, context_args: [:foo, :bar])
         end
+
+        it "wraps non-arrays passed to :context_args" do
+          worker = Factory::Worker.new(double, double)
+          worker.stub decorator: ->(*){}
+          context = ->{}
+          hash = {foo: "bar"}
+
+          context.should_receive(:call).with(hash)
+          worker.call(context: context, context_args: hash)
+        end
       end
 
       context "when the :context option is not callable" do


### PR DESCRIPTION
As @urbanautomaton points out on #478, because hashes support `to_a` they get splatted when passed as `context_args` [here](https://github.com/drapergem/draper/blob/668661f13aa2d216ea7ef3c88b4e11da102086e5/lib/draper/factory.rb#L83). This patch fixes this bug by wrapping the args in an array before splatting them.
