### PR TITLE
Delegate CollectionDecorator#kind_of? to the underlying decorated collection

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -71,6 +71,11 @@ module Draper
       true
     end
 
+    def kind_of?(klass)
+      decorated_collection.kind_of?(klass) || super
+    end
+    alias :is_a? :kind_of?
+
     protected
 
     # @return the collection being decorated.

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -259,5 +259,28 @@ module Draper
       end
     end
 
+    describe '#kind_of?' do
+      it 'asks the kind of its decorated collection' do
+        decorator = ProductsDecorator.new([])
+        decorator.decorated_collection.should_receive(:kind_of?).with(Array).and_return("true")
+        expect(decorator.kind_of?(Array)).to eq "true"
+      end
+
+      context 'when asking the underlying collection returns false' do
+        it 'asks the CollectionDecorator instance itself' do
+          decorator = ProductsDecorator.new([])
+          decorator.decorated_collection.stub(:kind_of?).with(::Draper::CollectionDecorator).and_return(false)
+          expect(decorator.kind_of?(::Draper::CollectionDecorator)).to be true
+        end
+      end
+    end
+
+    describe '#is_a?' do
+      it 'aliases to #kind_of?' do
+        decorator = ProductsDecorator.new([])
+        expect(decorator.method(:kind_of?)).to eq decorator.method(:is_a?)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Addresses a regression previously addressed in #92. The regression directly affects how nested forms are rendered for has_many associations decorated with 'decorates_associations'.
