### PR TITLE
Add #to_s method to rails version

### DIFF
--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -1,6 +1,6 @@
 require 'rake/testtask'
 
-test_task = if Rails.version.to_f < 3.2
+test_task = if Rails.version.to_s.to_f < 3.2
   require 'rails/test_unit/railtie'
   Rake::TestTask
 else


### PR DESCRIPTION
In Rails 4 master `Rails.version` return `Gem::Version`, so we need `to_s`.
