### PR TITLE
Document how to stub route helper functions in isolated tests. Addresses...

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,9 +393,12 @@ end
 #### Stubbing route helper functions
 
 If you are writing isolated tests for Draper methods that call route helper
-methods, you can stub them instead of needing to include Rails.
+methods, you can stub them instead of needing to require Rails.
 
-To get access to the Draper `helpers` in your test, include them in your tests:
+If you are using RSpec, minitest-rails, or the Test::Unit syntax of minitest,
+you already have access to the Draper `helpers` in your tests since they
+inherit from `Draper::TestCase`. If you are using minitest's spec syntax
+without minitest-rails, you can explicitly include the Draper `helpers`:
 
 ```ruby
 describe YourDecorator do
@@ -404,12 +407,11 @@ end
 ```
 
 Then you can stub the specific route helper functions you need using your
-preferred stubbing technique (this example uses mocha):
+preferred stubbing technique (this example uses RSpec's `stub` method):
 
 ```ruby
-helpers.stubs(users_path: '/users')
+helpers.stub(users_path: '/users')
 ```
-
 
 ## Advanced usage
 


### PR DESCRIPTION
... #506.

See the discussion in #506 about the issue this is addressing.

I'm happy to revise this however to best fit into the existing documentation. I'm also not entirely clear if this is a minitest specific thing or if it affects rspec as well. I'd also be fine with changing from mocha's `stubs` in the example to rspec's `stub` if readers of this documentation are more likely to be familiar with rspec's stubbing stuff.

I'm also cool with moving this to the wiki somewhere if this doesn't belong in the README.

Basically tell me how to change this and i'll be glad to do it :)
