### PR TITLE
Fix `CollectionDecorator#find`

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -48,7 +48,8 @@ module Draper
       if block_given?
         decorated_collection.find(*args, &block)
       else
-        decorator_class.find(*args)
+        ActiveSupport::Deprecation.warn("Using ActiveRecord's `find` on a CollectionDecorator is deprecated. Call `find` on a model, and then decorate the result", caller)
+        decorate_item(source.find(*args))
       end
     end
 

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -131,12 +131,15 @@ module Draper
       end
 
       context "without a block" do
-        it "decorates Model.find" do
-          item_decorator = Class.new
-          decorator = CollectionDecorator.new([], with: item_decorator)
+        it "decorates source.find" do
+          source = []
+          found = stub(decorate: :decorated)
+          decorator = CollectionDecorator.new(source)
 
-          item_decorator.should_receive(:find).with(1).and_return(:delegated)
-          expect(decorator.find(1)).to be :delegated
+          source.should_receive(:find).and_return(found)
+          ActiveSupport::Deprecation.silence do
+            expect(decorator.find(1)).to be :decorated
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes, and deprecates, the use of ActiveRecord's `find` method on a collection decorator.

Closes #509
