### PR TITLE
#decorate should always return the same Decorator object

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -15,7 +15,7 @@ module Draper
     # @param [Hash] options
     #   see {Decorator#initialize}
     def decorate(options = {})
-      decorator_class.decorate(self, options)
+      @decorated ||= decorator_class.decorate(self, options)
     end
 
     # (see ClassMethods#decorator_class)

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -26,6 +26,11 @@ module Draper
 
         expect(product.decorate).to be_an_instance_of OtherDecorator
       end
+
+      it "is memoized" do
+        product = Product.new
+        expect(product.decorate).to eq product.decorate
+      end
     end
 
     describe "#applied_decorators" do


### PR DESCRIPTION
Useful when you need to call `decorate` on the same object in multiple places, for example, in a view.
