### PR TITLE
Return self from CollectionDecorator#replace

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -74,6 +74,11 @@ module Draper
     end
     alias_method :is_a?, :kind_of?
 
+    def replace(other)
+      decorated_collection.replace(other)
+      self
+    end
+
     protected
 
     # @return the collection being decorated.

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -278,5 +278,21 @@ module Draper
       end
     end
 
+    describe "#replace" do
+      it "replaces the decorated collection" do
+        decorator = CollectionDecorator.new([Product.new])
+        replacement = [:foo, :bar]
+
+        decorator.replace replacement
+        expect(decorator).to match_array replacement
+      end
+
+      it "returns itself" do
+        decorator = CollectionDecorator.new([Product.new])
+
+        expect(decorator.replace([:foo, :bar])).to be decorator
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is necessary when storing CollectionDecorators in a HashWithIndifferentAccess, because of the way it [recursively converts values](https://github.com/rails/rails/blob/7cc26fd15e27c4a13705a844538bebfdd0461729/activesupport/lib/active_support/hash_with_indifferent_access.rb#L169-L170).

Closes #516.
