### PR TITLE
Fix decoration of unsaved collection associations

### DIFF
--- a/lib/draper/factory.rb
+++ b/lib/draper/factory.rb
@@ -59,7 +59,11 @@ module Draper
       attr_reader :decorator_class, :source
 
       def source_decorator
-        ->(source, options) { source.decorate(options) }
+        if collection?
+          ->(source, options) { source.decorator_class.decorate_collection(source, options.reverse_merge(with: nil))}
+        else
+          ->(source, options) { source.decorate(options) }
+        end
       end
 
       def decorator_method(klass)

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -213,13 +213,15 @@ module Draper
 
         context "when decorator_class is unspecified" do
           context "and the source is decoratable" do
-            it "returns the source's #decorate method" do
+            it "returns the .decorate_collection method from the source's decorator" do
               source = []
-              options = {foo: "bar"}
+              decorator_class = Class.new(Decorator)
+              source.stub decorator_class: decorator_class
+              source.stub decorate: nil
               worker = Factory::Worker.new(nil, source)
 
-              source.should_receive(:decorate).with(options).and_return(:decorated)
-              expect(worker.decorator.call(source, options)).to be :decorated
+              decorator_class.should_receive(:decorate_collection).with(source, foo: "bar", with: nil).and_return(:decorated)
+              expect(worker.decorator.call(source, foo: "bar")).to be :decorated
             end
           end
 


### PR DESCRIPTION
The changes to support STI introduced in #494 also introduced a bug... calling `#decorate` on an unsaved collection association forces a db lookup, clearing any items that have been added to the collection (e.g. using `#build`).

This fixes the problem by decorating the collection directly. It's not super pretty (because it basically copies code from `Decoratable.decorate`) but I will refactor it at some point in the future - for now I just want to unbreak it :)

Closes #518.
