### PR TITLE
Fix for drapergem/draper#482

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -183,6 +183,7 @@ module Draper
 
     # In case source is nil
     delegate :present?
+    delegate :blank?
 
     # ActiveModel compatibility
     # @private


### PR DESCRIPTION
Attends to the issue mentioned by @afrl re delegating the blank? method to source. All tests passing.
