### PR TITLE
Use block_given? in module_namespacing method

### DIFF
--- a/lib/generators/decorator/decorator_generator.rb
+++ b/lib/generators/decorator/decorator_generator.rb
@@ -27,8 +27,8 @@ module Rails
 
       # Rails 3.0.X compatibility, stolen from https://github.com/jnunemaker/mongomapper/pull/385/files#L1R32
       unless methods.include?(:module_namespacing)
-        def module_namespacing(&block)
-          yield if block
+        def module_namespacing
+          yield if block_given?
         end
       end
     end


### PR DESCRIPTION
Can't see any real reason to pass in an explicit block here as we just yield to it in any case. 
