### PR TITLE
Adds 'decoratable?' method to Draper::Decoratable

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -23,6 +23,10 @@ module Draper
       self.class.decorator_class
     end
 
+    def decorator_class?
+      self.class.decorator_class?
+    end
+
     # The list of decorators that have been applied to the object.
     #
     # @return [Array<Class>] `[]`
@@ -54,6 +58,12 @@ module Draper
       def decorate(options = {})
         collection = Rails::VERSION::MAJOR >= 4 ? all : scoped
         decorator_class.decorate_collection(collection, options.reverse_merge(with: nil))
+      end
+
+      def decorator_class?
+        decorator_class
+      rescue Draper::UninferrableDecoratorError
+        false
       end
 
       # Infers the decorator class to be used by {Decoratable#decorate} (e.g.

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -46,6 +46,26 @@ module Draper
       end
     end
 
+    describe "#decorator_class?" do
+      it "returns true for decoratable model" do
+        expect(Product.new.decorator_class?).to be_true
+      end
+
+      it "returns false for non-decoratable model" do
+        expect(Model.new.decorator_class?).to be_false
+      end
+    end
+
+    describe ".decorator_class?" do
+      it "returns true for decoratable model" do
+        expect(Product.decorator_class?).to be_true
+      end
+
+      it "returns false for non-decoratable model" do
+        expect(Model.decorator_class?).to be_false
+      end
+    end
+
     describe "#decorator_class" do
       it "delegates to .decorator_class" do
         product = Product.new


### PR DESCRIPTION
Indicates whether a class can be decorated or not without resorting to a
rescue in application-level code.  I needed to deal with decoratable and non-decoratable models in the same area, so this change pushes the rescue block down and out of sight.  I wasn't able to get rid of the rescue entirely, as I'm sure you've found yourselves, due to the decorators not being defined until they're autoloaded.
