### PR TITLE
Alias object to wrapped model name only if it can.

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -16,6 +16,15 @@ module Draper
     # @return [Hash] extra data to be used in user-defined methods.
     attr_accessor :context
 
+    def self.inherited(klass)
+      begin
+        alias_name = klass.name.downcase.gsub(/decorator/, "").to_sym
+        klass.send(:define_method, alias_name) do
+          object
+        end
+      rescue; end
+    end
+
     # Wraps an object in a new instance of the decorator.
     #
     # Decorators may be applied to other decorators. However, applying a
@@ -32,14 +41,6 @@ module Draper
       @object = object
       @context = options.fetch(:context, {})
       handle_multiple_decoration(options) if object.instance_of?(self.class)
-      alias_to_wrapped_model_name
-    end
-
-    def alias_to_wrapped_model_name
-      begin
-        wrapped_model_name = object.class.name.downcase.to_sym
-        Decorator.send(:alias_method, wrapped_model_name, :object)
-      rescue; end
     end
 
     class << self

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -362,13 +362,16 @@ module Draper
     end
 
     describe "aliasing object to wrapped model name" do
+      class ::ProductDecorator < Decorator; end
       class ::Product
         attr_reader :name
-        def initialize; @name = "bob"; end
+        def initialize
+          @name = "bob"
+        end
       end
 
       it "aliases object to wrapped model name" do
-        decorator = Decorator.new(Product.new)
+        decorator = ProductDecorator.new(Product.new)
 
         expect(decorator.product).not_to be nil
         expect(decorator.product.name).to eq "bob"


### PR DESCRIPTION
For instance if the wrapped model is an instance of Product there is
gonna be a method called :product which is aliased to :object.
- In jumpstartlab tutorial on using Draper for Decorator Pattern in rails in the blogger example there was a code that tried using a 'article' method in the ArticleDecorator but I kept getting the error "there is no such method 'article' in ArticleDecorator" so then I jumped into draper source and I saw that in the decorator.rb file there is no part that alias :object to wrapped model name (e.g. :article) or at least I couldn't find it!
- This pull request contains a test and associated code in decorator_spec.rb & decorator.rb for having the wrapped model name method in our decorators (e.g article)!
- It is the first step for this feature and I don't think it's complete or the best way to do that! I appreciate your feedback on it!

Thanks in advance,
Very Best of Regards,
