### PR TITLE
Clear ViewContext before specs instead of after

### DIFF
--- a/lib/draper/test/rspec_integration.rb
+++ b/lib/draper/test/rspec_integration.rb
@@ -10,7 +10,7 @@ module Draper
     config.include DecoratorExampleGroup, example_group: {file_path: %r{spec/decorators}}, type: :decorator
 
     [:decorator, :controller, :mailer].each do |type|
-      config.after(:each, type: type) { Draper::ViewContext.clear! }
+      config.before(:each, type: type) { Draper::ViewContext.clear! }
     end
   end
 end


### PR DESCRIPTION
By doing it before, we get sure that another type of spec (model,
acceptance) does not leave ViewContext in a wrong context...

https://github.com/drapergem/draper/issues/523
