### PR TITLE
remove check for parent_class_name from decorator template

### DIFF
--- a/lib/generators/rails/templates/decorator.rb
+++ b/lib/generators/rails/templates/decorator.rb
@@ -1,9 +1,5 @@
 <%- module_namespacing do -%>
-  <%- if parent_class_name.present? -%>
 class <%= class_name %>Decorator < <%= parent_class_name %>
-  <%- else -%>
-class <%= class_name %>
-  <%- end -%>
   delegate_all
 
   # Define presentation-specific methods here. Helpers are accessed through


### PR DESCRIPTION
The only way to trigger the else clause is to explicitly set the --parent option to something blank. I do not see why you would want to do this but I might be missing something here.

If this is on purpose it lacks a spec and the naming strategy is inconsistent in that it does not add the Decorator to the class_name.