### PR TITLE
Allow creation of collection decorator with --collection option

### DIFF
--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -5,9 +5,16 @@ module Rails
       check_class_collision suffix: "Decorator"
 
       class_option :parent, type: :string, desc: "The parent class for the generated decorator"
+      class_option :collection, type: :boolean, desc: "Also create a collection decorator for the given class"
+      class_option :collection_parent, type: :string, desc: "The parent class for the optionally generated collection decorator"
 
       def create_decorator_file
         template 'decorator.rb', File.join('app/decorators', class_path, "#{file_name}_decorator.rb")
+      end
+
+      def create_collection_decorator_file
+        return unless options["collection"]
+        template 'collection_decorator.rb', File.join('app/decorators', class_path, "#{plural_file_name}_decorator.rb")
       end
 
       hook_for :test_framework
@@ -21,6 +28,17 @@ module Rails
             ApplicationDecorator
           rescue LoadError
             "Draper::Decorator"
+          end
+        end
+      end
+
+      def collection_parent_class_name
+        options.fetch("collection_parent") do
+          begin
+            require 'collection_decorator'
+            CollectionDecorator
+          rescue LoadError
+            "Draper::CollectionDecorator"
           end
         end
       end

--- a/lib/generators/rails/templates/collection_decorator.rb
+++ b/lib/generators/rails/templates/collection_decorator.rb
@@ -1,0 +1,15 @@
+<%- module_namespacing do -%>
+class <%= class_name.pluralize %>Decorator < <%= collection_parent_class_name %>
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def heading
+  #     helpers.content_tag :h3, class: 'collection' do
+  #       "#{count} ".html_safe + klass.name.humanize(count: count)
+  #     end
+  #   end
+
+end
+<% end -%>

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -52,6 +52,50 @@ describe Rails::Generators::DecoratorGenerator do
     end
   end
 
+  describe "the generated decorator" do
+    subject { file("app/decorators/your_models_decorator.rb") }
+
+    describe "naming" do
+      before { run_generator %w(YourModel --collection) }
+
+      it { should contain "class YourModelsDecorator" }
+    end
+
+    describe "namespacing" do
+      subject { file("app/decorators/namespace/your_models_decorator.rb") }
+      before { run_generator %w(Namespace::YourModel --collection) }
+
+      it { should contain "class Namespace::YourModelsDecorator" }
+    end
+
+    describe "inheritance" do
+      context "by default" do
+        before { run_generator %w(YourModel --collection) }
+
+        it { should contain "class YourModelsDecorator < Draper::CollectionDecorator" }
+      end
+
+      context "with the --parent option" do
+        before { run_generator %w(YourModel --collection --collection_parent=FooDecorator) }
+
+        it { should contain "class YourModelsDecorator < FooDecorator" }
+      end
+
+      context "with a CollectionDecorator" do
+        before do
+          Object.any_instance.stub(:require).with("application_decorator").and_raise(LoadError)
+          Object.any_instance.stub(:require).with("collection_decorator").and_return do
+            stub_const "CollectionDecorator", Class.new
+          end
+        end
+
+        before { run_generator %w(YourModel --collection) }
+
+        it { should contain "class YourModelsDecorator < CollectionDecorator" }
+      end
+    end
+  end
+
   context "with -t=rspec" do
     describe "the generated spec" do
       subject { file("spec/decorators/your_model_decorator_spec.rb") }


### PR DESCRIPTION
This allows relying on the existance of a collection decorator in your index view template.

Also respects --collection_parent option for the parent class for the collection decorator.
It will use CollectionDecorator as the parent if available and fall back to Draper::CollectionDecorator.

Including specs for the new generator functionality.

There's quite a bit of code duplication for the inheritance. This shows up in the generator code as well as in the spec.

I decided not to refactor this as it seems more clear to me this way.

Still Missing:
* tests for the generated collection decorator
* documentation for the new options in the readme