### PR TITLE
Fix Decorator#inspect on Ruby 1.9

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -188,6 +188,18 @@ module Draper
       super || object.instance_of?(klass)
     end
 
+    if RUBY_VERSION < "2.0"
+      # nasty hack to stop 1.9.x using the delegated `to_s` in `inspect`
+      alias_method :_to_s, :to_s
+
+      def inspect
+        ivars = instance_variables.map do |name|
+          "#{name}=#{instance_variable_get(name).inspect}"
+        end
+        _to_s.insert(-2, " #{ivars.join(", ")}")
+      end
+    end
+
     delegate :to_s
 
     # In case object is nil

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -449,6 +449,33 @@ module Draper
       end
     end
 
+    describe "#inspect" do
+      it "returns a detailed description of the decorator" do
+        decorator = ProductDecorator.new(double)
+
+        expect(decorator.inspect).to match /#<ProductDecorator:0x\h+ .+>/
+      end
+
+      it "includes the object" do
+        decorator = Decorator.new(double(inspect: "#<the object>"))
+
+        expect(decorator.inspect).to include "@object=#<the object>"
+      end
+
+      it "includes the context" do
+        decorator = Decorator.new(double, context: {foo: "bar"})
+
+        expect(decorator.inspect).to include '@context={:foo=>"bar"}'
+      end
+
+      it "includes other instance variables" do
+        decorator = Decorator.new(double)
+        decorator.instance_variable_set :@foo, "bar"
+
+        expect(decorator.inspect).to include '@foo="bar"'
+      end
+    end
+
     describe "#attributes" do
       it "returns only the object's attributes that are implemented by the decorator" do
         decorator = Decorator.new(double(attributes: {foo: "bar", baz: "qux"}))


### PR DESCRIPTION
As [pointed out](https://github.com/drapergem/draper/issues/560#issuecomment-20579840), Ruby 1.9 uses `to_s`, if defined, for `inspect`, so with `to_s` delegated (#561), it's difficult to distinguish the decorator from the object at the console.

This hacks `inspect` to return the same thing on 1.9 as it does on 2.0
