### PR TITLE
Unexpected behavior using to_json on a decorated object.

### DIFF
--- a/spec/dummy/spec/decorators/post_decorator_spec.rb
+++ b/spec/dummy/spec/decorators/post_decorator_spec.rb
@@ -53,6 +53,18 @@ describe PostDecorator do
     expect(json).to match /"updated_at":"overridden"/
   end
 
+  it "honors include_root_in_json when false" do
+    Post.include_root_in_json = false
+    json = decorator.to_json
+    expect(json).to match Regexp.new("^{\"id\":#{decorator.id}")
+  end
+
+  it "honors include_root_in_json when true" do
+    Post.include_root_in_json = true
+    json = decorator.to_json
+    expect(json).to match Regexp.new("^{\"post\":{\"id\":#{decorator.id}")
+  end
+
   it "serializes to XML" do
     pending("Rails < 3.2 does not use `serializable_hash` in `to_xml`") if Rails.version.to_f < 3.2
 


### PR DESCRIPTION
Hey guys,

First of all, thanks for the gem. We love it.

We had some unexpected behavior with draper and the `to_json` method. Basically, we were expecting it to behave like the following:

From a Rails 3.2.13 console.

``` ruby
Task.include_root_in_json = true
 => true 
task.to_json(only: :id)
 => "{\"task\":{\"id\":1}}" 
Task.include_root_in_json = false
 => false 
task.to_json(only: :id)
 => "{\"id\":1}"
```

But with a decorated object, we get this unexpected behavior:

``` ruby
Task.include_root_in_json = true
 => true 
task.decorate.to_json(only: :id)
 => "{\"task\":{\"id\":1}}" 
Task.include_root_in_json = false
 => false 
task.decorate.to_json(only: :id)
 => "{\"task\":{\"id\":1}}"
```

We have `include_root_in_json` set to false in an initializer like so:

``` ruby
ActiveSupport.on_load(:active_record) do
  self.include_root_in_json = false
end
```

We worked around the issue by delegating `to_json` inside the decorator. I tried to write a good failing test to illustrate the unexpected behavior. I saw #101 which mentioned a similar situation - any thoughts on this?
