### PR TITLE
Add activemodel runtime dependency.

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'actionpack', '>= 3.0'
   s.add_dependency 'request_store', '~> 1.0.3'
+  s.add_dependency 'activemodel', '>= 3.0'
 
   s.add_development_dependency 'ammeter'
   s.add_development_dependency 'rake', '>= 0.9.2'


### PR DESCRIPTION
Draper requires activemodel in `lib/draper.rb` line 2-4 but does not declare it as a dependency. 

When using draper outside a full rails environment it fails with a LoadError:

```
draper/lib/draper.rb:2:in `require': cannot load such file -- active_model/naming (LoadError)
```

Draper tests are passing because development dependency `active_model_serializers` has `active_model` as a dependency.
