### PR TITLE
Remove deprecation warnings when using minitest-rails 0.9 and higher

### DIFF
--- a/lib/draper/test_case.rb
+++ b/lib/draper/test_case.rb
@@ -1,12 +1,17 @@
 module Draper
   begin
+    require "rails/test_help"
     require 'minitest/rails'
   rescue LoadError
   end
 
   active_support_test_case = begin
     require 'minitest/rails/active_support' # minitest-rails < 0.5
-    ::MiniTest::Rails::ActiveSupport::TestCase
+    if ::MiniTest::Rails::VERSION < "0.9"
+      ::MiniTest::Rails::ActiveSupport::TestCase
+    else
+      ::ActiveSupport::TestCase
+    end
   rescue LoadError
     require 'active_support/test_case'
     ::ActiveSupport::TestCase


### PR DESCRIPTION
The patch removes deprecation warnings generated by requiring Draper into an app that uses minitest-rails 0.9 and above. The changes were performed according to the minitest [Upgrading to 0.9](https://github.com/blowmage/minitest-rails/wiki/Upgrading-to-0.9) page.

No new tests are added, but if you upgrade bundle to use minitest-rails 0.9 you'll see that deprecation warnings have disappeard.

Cheers!
