### PR TITLE
Renamed minitest helper to test_helper

### DIFF
--- a/lib/generators/mini_test/templates/decorator_spec.rb
+++ b/lib/generators/mini_test/templates/decorator_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest_helper'
+require 'test_helper'
 
 describe <%= class_name %>Decorator do
 end

--- a/lib/generators/mini_test/templates/decorator_test.rb
+++ b/lib/generators/mini_test/templates/decorator_test.rb
@@ -1,4 +1,4 @@
-require 'minitest_helper'
+require 'test_helper'
 
 class <%= class_name %>DecoratorTest < Draper::TestCase
 end


### PR DESCRIPTION
The minitest helper is not called `minitest_helper` anymore but `test_helper` instead.
See: https://github.com/blowmage/minitest-rails/wiki/Upgrading-to-0.9
