### PR TITLE
Collection decorator readers

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -81,10 +81,7 @@ module Draper
 
     # @return the collection being decorated.
     attr_reader :object
-
     alias_method :model, :object
-    alias_method :source, :object # TODO: deprecate this
-    alias_method :to_source, :object # TODO: deprecate this
 
     # Decorates the given item.
     def decorate_item(item)

--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -82,6 +82,10 @@ module Draper
     # @return the collection being decorated.
     attr_reader :object
 
+    alias_method :model, :object
+    alias_method :source, :object # TODO: deprecate this
+    alias_method :to_source, :object # TODO: deprecate this
+
     # Decorates the given item.
     def decorate_item(item)
       item_decorator.call(item, context: context)

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -255,6 +255,19 @@ module Draper
       end
     end
 
+    describe "#object" do
+      it "returns the wrapped collection object" do
+        decorator_class = Class.new(Draper::CollectionDecorator) do
+          def sum
+            object.sum < 0 ? "-" : "+"
+          end
+        end
+
+        decorator = decorator_class.new([1])
+        expect(decorator.sum).to eq '+'
+      end
+    end
+
     describe '#kind_of?' do
       it 'asks the kind of its decorated collection' do
         decorator = ProductsDecorator.new([])

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -256,12 +256,17 @@ module Draper
     end
 
     describe "#object" do
-      it "returns the wrapped collection object" do
+      it "returns the wrapped collection object to subclasses" do
         products = [Product.new]
         decorator = ProductsDecorator.new(products)
 
         decorator.define_singleton_method(:expose_object) { object }
         expect(decorator.expose_object).to eq products
+      end
+
+      it "is not public" do
+        decorator = ProductsDecorator.new([Product.new])
+        expect(decorator).to_not respond_to :object
       end
 
       it "is aliased to #model" do
@@ -270,6 +275,11 @@ module Draper
 
         decorator.define_singleton_method(:expose_model) { model }
         expect(decorator.expose_model).to eq products
+      end
+
+      it "does not create public aliases" do
+        decorator = ProductsDecorator.new([Product.new])
+        expect(decorator).to_not respond_to :model
       end
     end
 

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -257,25 +257,19 @@ module Draper
 
     describe "#object" do
       it "returns the wrapped collection object" do
-        decorator_class = Class.new(Draper::CollectionDecorator) do
-          def sum
-            object.sum < 0 ? "-" : "+"
-          end
-        end
+        products = [Product.new]
+        decorator = ProductsDecorator.new(products)
 
-        decorator = decorator_class.new([1])
-        expect(decorator.sum).to eq '+'
+        decorator.define_singleton_method(:expose_object) { object }
+        expect(decorator.expose_object).to eq products
       end
 
       it "is aliased to #model" do
-        decorator_class = Class.new(Draper::CollectionDecorator) do
-          def sum
-            model.sum < 0 ? "-" : "+"
-          end
-        end
+        products = [Product.new]
+        decorator = ProductsDecorator.new(products)
 
-        decorator = decorator_class.new([1])
-        expect(decorator.sum).to eq '+'
+        decorator.define_singleton_method(:expose_model) { model }
+        expect(decorator.expose_model).to eq products
       end
     end
 

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -266,6 +266,39 @@ module Draper
         decorator = decorator_class.new([1])
         expect(decorator.sum).to eq '+'
       end
+
+      it "is aliased to #model" do
+        decorator_class = Class.new(Draper::CollectionDecorator) do
+          def sum
+            model.sum < 0 ? "-" : "+"
+          end
+        end
+
+        decorator = decorator_class.new([1])
+        expect(decorator.sum).to eq '+'
+      end
+
+      it "is aliased to #source" do
+        decorator_class = Class.new(Draper::CollectionDecorator) do
+          def sum
+            source.sum < 0 ? "-" : "+"
+          end
+        end
+
+        decorator = decorator_class.new([1])
+        expect(decorator.sum).to eq '+'
+      end
+
+      it "is aliased to #to_source" do
+        decorator_class = Class.new(Draper::CollectionDecorator) do
+          def sum
+            to_source.sum < 0 ? "-" : "+"
+          end
+        end
+
+        decorator = decorator_class.new([1])
+        expect(decorator.sum).to eq '+'
+      end
     end
 
     describe '#kind_of?' do

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -277,28 +277,6 @@ module Draper
         decorator = decorator_class.new([1])
         expect(decorator.sum).to eq '+'
       end
-
-      it "is aliased to #source" do
-        decorator_class = Class.new(Draper::CollectionDecorator) do
-          def sum
-            source.sum < 0 ? "-" : "+"
-          end
-        end
-
-        decorator = decorator_class.new([1])
-        expect(decorator.sum).to eq '+'
-      end
-
-      it "is aliased to #to_source" do
-        decorator_class = Class.new(Draper::CollectionDecorator) do
-          def sum
-            to_source.sum < 0 ? "-" : "+"
-          end
-        end
-
-        decorator = decorator_class.new([1])
-        expect(decorator.sum).to eq '+'
-      end
     end
 
     describe '#kind_of?' do


### PR DESCRIPTION
The Decorator class allows subclasses to reference the object being decorated with #object, #source, #model, or #to_source.  I happened to be familiar with #model and was surprised when this wasn't available in a CollectionDecorator.  This PR adds the same aliases to CollectionDecorator that Decorator has.

It was kind of funky to test because these are protected methods, so in the test I created subclasses of CollectionDecorator that used the protected method.  They could also just use send if you'd prefer that.

@ckundo Check it out :)