### PR TITLE
Resolving some nuances with equality

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -173,10 +173,17 @@ module Draper
       Draper::Decoratable::Equality.test(object, other)
     end
 
+    # Delegates equality to :== as expected
+    #
+    # @return [Boolean]
     def eql?(other)
       self == other
     end
 
+    # Returns a unique hash for a decorated object based on
+    # the decorator class and the object being decorated.
+    # 
+    # @return [Fixnum]
     def hash
       self.class.hash ^ object.hash
     end

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -173,6 +173,14 @@ module Draper
       Draper::Decoratable::Equality.test(object, other)
     end
 
+    def eql?(other)
+      self == other
+    end
+
+    def hash
+      self.class.hash ^ object.hash
+    end
+
     # Checks if `self.kind_of?(klass)` or `object.kind_of?(klass)`
     #
     # @param [Class] klass

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -561,11 +561,9 @@ module Draper
 
     describe "#hash" do
       it "is consistent for equal objects" do
-        first = Decorator.new(Model.new)
-        second = Decorator.new(Model.new)
-        # TODO: The above two lines have different hashes...?
-        first = Decorator.new('foo')
-        second = Decorator.new('foo')
+        object = Model.new
+        first = Decorator.new(object)
+        second = Decorator.new(object)
 
         expect(first.hash == second.hash).to be_true
       end

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -781,5 +781,35 @@ module Draper
       end
     end
 
+    describe "Enumerable hash and equality functionality" do
+      describe "#uniq" do
+        it "removes duplicate objects with same decorator" do
+          object = Model.new
+          array = [Decorator.new(object), Decorator.new(object)]
+
+          expect(array.uniq.count).to eq(1)
+        end
+
+        it "separates different objects with identical decorators" do
+          array = [Decorator.new('foo'), Decorator.new('bar')]
+
+          expect(array.uniq.count).to eq(2)
+        end
+
+        it "separates identical objects with different decorators" do
+          object = Model.new
+          array = [Decorator.new(object), OtherDecorator.new(object)]
+
+          expect(array.uniq.count).to eq(2)
+        end
+
+        it "distinguishes between an objects and its decorated version" do
+          object = Model.new
+          array = [Decorator.new(object), object]
+
+          expect(array.uniq.count).to eq(2)
+        end
+      end
+    end
   end
 end

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -525,7 +525,6 @@ module Draper
         object.should_receive(:==).with(other).and_return(false)
         expect(decorator == other).to be_false
       end
-
     end
 
     describe "#===" do
@@ -541,6 +540,31 @@ module Draper
         decorator.stub(:==).with(:anything).and_return(false)
 
         expect(decorator === :anything).to be_false
+      end
+    end
+
+    describe "#eql?" do
+      it "is true when #eql? is true" do
+        first = Decorator.new('foo')
+        second = Decorator.new('foo')
+
+        expect(first.eql? second).to be_true
+      end
+
+      it "is false when #eql? is false" do
+        first = Decorator.new('foo')
+        second = Decorator.new('bar')
+
+        expect(first.eql? second).to be_false
+      end
+    end
+
+    describe "#hash" do
+      it "is consistent for equal objects" do
+        first = Decorator.new(Model.new)
+        second = Decorator.new(Model.new)
+
+        expect(first.hash == second.hash).to be_true
       end
     end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -563,6 +563,9 @@ module Draper
       it "is consistent for equal objects" do
         first = Decorator.new(Model.new)
         second = Decorator.new(Model.new)
+        # TODO: The above two lines have different hashes...?
+        first = Decorator.new('foo')
+        second = Decorator.new('foo')
 
         expect(first.hash == second.hash).to be_true
       end


### PR DESCRIPTION
I noticed some strangeness with how equality works on decorated objects. This is particularly prevalent when dealing with collections of objects and using methods provided by Enumerable. This is a pull request to try and resolve this, at the moment it is just a failing test.

An easy example:
```ruby
model = Model.first
[model, model].uniq.count => 1
[model.decorate, model.decorate].uniq.count => 2
```

Looking into it in more detail it seems a lot of these methods rely on a combination of ```#eql?``` and ```#hash```. Both of these return unexpected results currently. This caused a lot of confusion since ```#group_by``` on a collection wouldn't group, despite many keys being equal. This is particularly a problem when using decorated associations.

This is shown below:
```ruby
irb(main):006:0> model.decorate.eql? model.decorate
=> false
irb(main):007:0> model.decorate.hash
=> -521953688451298283
irb(main):008:0> model.decorate.hash
=> 573320235355283849
```

I "fixed" this in the problem area by adding the following two methods to the decorator which I was using.
```ruby
ModelDecorator < Draper::Decorator
  def eql?(other)
    self == other
  end

  def hash
    object.hash
  end
end
```

I think the ```#eql?``` implementation might be fine. I'm not sure, but I think the ```#hash``` isn't "correct" since it will match the undecorated object.

I'll have more of a look at the code later for a possible fix. How does this sound? Any idea of an appropriate way of generating the hash?

Also any advice where this code would go? I tried to put my ```#eql?``` definition in [Draper::Decoratable::Equality](lib/draper/decoratable/equality.rb) but it still failed the tests (code isn't committed since it didn't help).