### PR TITLE
Decorators generated via controller generator hooks have singular names

### DIFF
--- a/lib/generators/controller_override.rb
+++ b/lib/generators/controller_override.rb
@@ -5,7 +5,9 @@ require "rails/generators/rails/scaffold_controller/scaffold_controller_generato
 module Rails
   module Generators
     class ControllerGenerator
-      hook_for :decorator, default: true
+      hook_for :decorator, default: true do |generator|
+        invoke generator, [name.singularize]
+      end
     end
 
     class ScaffoldControllerGenerator

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'rails'
+require 'ammeter/init'
+require 'generators/controller_override'
+require 'generators/rails/decorator_generator'
+
+describe Rails::Generators::ControllerGenerator do
+  destination File.expand_path("../tmp", __FILE__)
+
+  before { prepare_destination }
+  after(:all) { FileUtils.rm_rf destination_root }
+
+  describe "the generated decorator" do
+    subject { file("app/decorators/your_model_decorator.rb") }
+
+    describe "naming" do
+      before { run_generator %w(YourModels) }
+
+      it { should contain "class YourModelDecorator" }
+    end
+  end
+end


### PR DESCRIPTION
Previously, decorators generated via:

```
rails g decorator model
```

would be named `ModelGenerator`, whereas decorators generated via:

```
rails g controller models
rails g resource model
```

would be named `ModelsGenerator`, even though all cases generated model decorators, not controller decorators. This discrepancy broke the default class lookup for `@model.decorate`, and so this pull request unifies the behavior of all generators to create decorators named in the singular.

I'm sure there's a better implementation here, and I'm happy to do that; just let me know what's best!
