### PR TITLE
change protected attr_reader :object to public reader

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -12,6 +12,9 @@ module Draper
     #   to each item's decorator.
     attr_accessor :context
 
+    # @return the collection being decorated.
+    attr_reader :object
+
     array_methods = Array.instance_methods - Object.instance_methods
     delegate :==, :as_json, *array_methods, to: :decorated_collection
 
@@ -78,9 +81,6 @@ module Draper
     end
 
     protected
-
-    # @return the collection being decorated.
-    attr_reader :object
 
     # Decorates the given item.
     def decorate_item(item)


### PR DESCRIPTION
...seriously, why is it protected ? :rage3: 

Sometimes one needs to access the original undecorated collection without calling `send` method. E.g. : passing it to policy object.

or if you guys are concern about the name, I can just do public alias called `collection` 
