### PR TITLE
Bring back compatibility with ActiveModel::Serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta2"
 end
 
-version = ENV["RAILS_VERSION"] || "4.0"
+version = ENV["RAILS_VERSION"] || "4.1"
 
 eval_gemfile File.expand_path("../gemfiles/#{version}.gemfile", __FILE__)

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,3 +1,3 @@
 gem "rails", "~> 4.0.0"
-gem "mongoid", github: "mongoid/mongoid"
+gem "mongoid", "~> 4.0"
 gem "devise", "~> 3.0.0"

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,2 +1,3 @@
-gem "rails", github: "rails/rails"
-gem "devise", github: "plataformatec/devise"
+gem "rails", "~> 4.1.0"
+gem "mongoid", "~> 4.0"
+gem "devise", "~> 3.2"

--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -45,7 +45,9 @@ module Draper
 
     initializer "draper.setup_active_model_serializers" do |app|
       ActiveSupport.on_load :active_model_serializers do
-        Draper::CollectionDecorator.send :include, ActiveModel::ArraySerializerSupport
+        if defined?(ActiveModel::ArraySerializerSupport)
+          Draper::CollectionDecorator.send :include, ActiveModel::ArraySerializerSupport
+        end
       end
     end
 

--- a/spec/dummy/spec/decorators/active_model_serializers_spec.rb
+++ b/spec/dummy/spec/decorators/active_model_serializers_spec.rb
@@ -4,8 +4,13 @@ describe Draper::CollectionDecorator do
   describe "#active_model_serializer" do
     it "returns ActiveModel::ArraySerializer" do
       collection_decorator = Draper::CollectionDecorator.new([])
+      if defined?(ActiveModel::ArraySerializerSupport)
+        collection_serializer = collection_decorator.active_model_serializer
+      else
+        collection_serializer = ActiveModel::Serializer.serializer_for(collection_decorator)
+      end
 
-      expect(collection_decorator.active_model_serializer).to be ActiveModel::ArraySerializer
+      expect(collection_serializer).to be ActiveModel::ArraySerializer
     end
   end
 end


### PR DESCRIPTION
The current AMS re-write (which will debut as v0.9.0) has changed how serializers are resolved, and removed the `ArraySerializerSupport` module. This change will ensure Draper properly integrates with both AMS pre-0.9.0, and the future.

I went with the obvious approach, but another option would be to instead test the current loaded version of `active_model_serializers` instead. So, sub out those `if defined?(ActiveModel::ArraySerializerSupport)` checks for something like `Gem.loaded_specs['active_model_serializers'].version.release < Gem::Version.new('0.9')`.

Thoughts?