### PR TITLE
Add test for case when decorator in module but not model

### DIFF
--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -88,6 +88,16 @@ module Draper
           expect(redecorated.object).to be decorated
         end
       end
+
+      context 'when decorator is under a namespace but model is not' do
+        it 'decorates the model properly' do
+          model = Model.new
+          decorator = Namespaced::OtherDecorator.new(model)
+
+          expect(decorator).to be_instance_of Namespaced::OtherDecorator
+          expect(decorator.object).to eq model
+        end
+      end
     end
 
     describe "#context=" do


### PR DESCRIPTION
We have `1.2.1` version in our project. A case when a decorator is under namespace and model is not is failed:

```
.../draper-1.2.1/lib/draper/decorator.rb:233:in `rescue in inferred_object_class': Could not infer a source for Client::SubscriptionDecorator. (Draper::UninferrableSourceError)
```

Code example:

```ruby
module Client
  class SubscriptionDecorator < Draper::Decorator
  end
end

class Subscription
end

Client::SubscriptionDecorator.new(Subscription.new)
```