### PR TITLE
Decorate structs as singular objects (and not as collections)

### DIFF
--- a/lib/draper/factory.rb
+++ b/lib/draper/factory.rb
@@ -75,7 +75,7 @@ module Draper
       end
 
       def collection?
-        object.respond_to?(:first)
+        object.respond_to?(:first) && !object.is_a?(Struct)
       end
 
       def decoratable?

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -190,6 +190,17 @@ module Draper
             end
           end
         end
+
+        context "when the object is a struct" do
+          it "returns a singular decorator" do
+            object = Struct.new(:stuff).new("things")
+
+            decorator_class = Class.new(Decorator)
+            worker = Factory::Worker.new(decorator_class, object)
+
+            expect(worker.decorator).to eq decorator_class.method(:decorate)
+          end
+        end
       end
 
       context "for a collection object" do


### PR DESCRIPTION
Since structs respond to `.first`, Draper thinks they're collections and
always tries to wrap them in CollectionDecorators, which is surprising!

This is similar to the issue and fix in [#259].