### PR TITLE
Draper.undecorate safely undecorates any object

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -22,6 +22,7 @@ require 'draper/decorated_association'
 require 'draper/helper_support'
 require 'draper/view_context'
 require 'draper/collection_decorator'
+require 'draper/undecorate'
 require 'draper/decorates_assigned'
 require 'draper/railtie' if defined?(Rails)
 

--- a/lib/draper/undecorate.rb
+++ b/lib/draper/undecorate.rb
@@ -1,0 +1,9 @@
+module Draper
+  def self.undecorate(object)
+    if object.respond_to?(:decorated?) && object.decorated?
+      object.object
+    else
+      object
+    end
+  end
+end

--- a/spec/draper/undecorate_spec.rb
+++ b/spec/draper/undecorate_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Draper, '.undecorate' do
+  it 'undecorates a decorated object' do
+    object = Model.new
+    decorator = Draper::Decorator.new(object)
+    expect(Draper.undecorate(decorator)).to equal object
+  end
+
+  it 'passes a non-decorated object through' do
+    object = Model.new
+    expect(Draper.undecorate(object)).to equal object
+  end
+
+  it 'passes a non-decorator object through' do
+    object = Object.new
+    expect(Draper.undecorate(object)).to equal object
+  end
+end


### PR DESCRIPTION
This allows you to pass any object to `Draper.undecorate` knowing you will get the original object back
even if the object passed in does is not already decorated.

Closes #600
