### PR TITLE
Fix dummy mongoid config.

### DIFF
--- a/spec/dummy/config/mongoid.yml
+++ b/spec/dummy/config/mongoid.yml
@@ -73,7 +73,6 @@ test:
       hosts:
         - localhost:27017
       options:
-        consistency: :strong
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1


### PR DESCRIPTION
Specs are broken because of new version of mongoid.
Changelog (https://github.com/mongoid/mongoid/blob/master/CHANGELOG.md) says that `:consistency` option was removed and we should use `:read` option, but its default value is what these specs need.
