### PR TITLE
Make Draper::CollectionDecorator#object public

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -4,6 +4,9 @@ module Draper
     include Draper::ViewHelpers
     extend Draper::Delegation
 
+    # @return the collection being decorated.
+    attr_reader :object
+
     # @return [Class] the decorator class used to decorate each item, as set by
     #   {#initialize}.
     attr_reader :decorator_class
@@ -78,9 +81,6 @@ module Draper
     end
 
     protected
-
-    # @return the collection being decorated.
-    attr_reader :object
 
     # Decorates the given item.
     def decorate_item(item)

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -238,6 +238,15 @@ module Draper
       end
     end
 
+    describe '#object' do
+      it 'returns the underlying collection' do
+        collection = [Product.new]
+        decorator = ProductsDecorator.new(collection)
+
+        expect(decorator.object).to eq collection
+      end
+    end
+
     describe '#decorated?' do
       it 'returns true' do
         decorator = ProductsDecorator.new([Product.new])


### PR DESCRIPTION
`Draper::Decorator#object` is public, so it would be consistent if `Draper::CollectionDecorator#object` is also public. And it makes sense to choose "public", because users should be able to access the underlying objects.
