### PR TITLE
Allow HelperProxy to handle respond_to?

### DIFF
--- a/lib/draper/helper_proxy.rb
+++ b/lib/draper/helper_proxy.rb
@@ -16,6 +16,12 @@ module Draper
       send(method, *args, &block)
     end
 
+    # Checks if the context responds to an instance method, or is able to
+    # proxy it to the view context.
+    def respond_to_missing?(method, include_private = false)
+      super || view_context.respond_to?(method)
+    end
+
     delegate :capture, to: :view_context
 
     protected

--- a/spec/draper/helper_proxy_spec.rb
+++ b/spec/draper/helper_proxy_spec.rb
@@ -39,6 +39,14 @@ module Draper
       end
     end
 
+    describe "#respond_to_missing?" do
+      it "allows #method to be called on the view context" do
+        helper_proxy = HelperProxy.new(double(foo: "bar"))
+
+        expect(helper_proxy.respond_to?(:foo)).to be_true
+      end
+    end
+
     describe "proxying methods which are overriding" do
       it "proxies :capture" do
         view_context = double


### PR DESCRIPTION
There are cases where, in my decorator, I'd like to make sure the context responds to a method before calling it (eg `#current_user`).

``` ruby
class MyDecorator < Draper::Decorator
  def something_with_current_user
    h.current_user if h.respond_to?(:current_user)
  end
end
```

Adding `#respond_to_missing?` allows me to ask if the view context has the method I'm looking for.
