### PR TITLE
Update README, extra kaminari methods delegation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ the `object`:
 
 ```ruby
 class PaginatingDecorator < Draper::CollectionDecorator
-  delegate :current_page, :total_pages, :limit_value
+  delegate :current_page, :total_pages, :limit_value, :entry_name, :total_count, :offset_value, :last_page?
 end
 ```
 


### PR DESCRIPTION
  - In order to use kaminari's helper method `page_entries_info`, you
    need to delegate `:entry_name`, `:total_count`, `:offset_value` and
    `:last_page?`.