### PR TITLE
Update travis ci badge to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Draper: View Models for Rails
 
-[![TravisCI Build Status](https://secure.travis-ci.org/drapergem/draper.png?branch=master)](http://travis-ci.org/drapergem/draper)
+[![TravisCI Build Status](https://travis-ci.org/drapergem/draper.svg?branch=master)](http://travis-ci.org/drapergem/draper)
 [![Code Climate](https://codeclimate.com/github/drapergem/draper.png)](https://codeclimate.com/github/drapergem/draper)
 
 Draper adds an object-oriented layer of presentation logic to your Rails


### PR DESCRIPTION
Updates the travis ci badge to use svg instead of png. 
http://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/
