### PR TITLE
Relax required version of request_store

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'actionpack', '>= 3.0'
-  s.add_dependency 'request_store', '~> 1.0.3'
+  s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'activemodel', '>= 3.0'
 
   s.add_development_dependency 'ammeter'


### PR DESCRIPTION
Version 1.1.0 of the `request_store` gem is released. Bundler resolves draper to some old version for projects using both `draper` and `request_store`.

This PR relaxes the required version.
