### PR TITLE
Don't auto add test:decorators to test:run

### DIFF
--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -15,7 +15,7 @@ namespace :test do
   end
 end
 
-if Rake::Task.task_defined?('test:run')
+if Rails.version.to_f < 4.2 && Rake::Task.task_defined?('test:run')
   Rake::Task['test:run'].enhance do
     Rake::Task['test:decorators'].invoke
   end


### PR DESCRIPTION
Prior to Rails 4.2 if you ran `rake test` (which in turn ran `rake test:run`) it would only run tests in specific directories. So if you had a new type of file (such as decorators) you needed to append this rake task to include your new file type.

As of [commit 3b12abb in Rails](https://github.com/rails/rails/commit/3b12abba3c4fa0dbd6e8c92bd68fa433847d142c) this is no longer neccessary. The old `rake test:all` which was more inclusive (ran all tests under the `test/` directory) became `rake test`. The old `rake test` that only ran specific directories was removed.

This commit removes the special addition of running the decorator tests. Without this, running `rake test` will first test the decorators, then it will test all files (including the decorators).