### PR TITLE
required v0.8.0 for active_model_serializers in gemspec

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'minitest-rails', '>= 1.0'
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'active_model_serializers'
+  s.add_development_dependency 'active_model_serializers', '~> 0.8.0'
 end


### PR DESCRIPTION
This makes all tests pass on rails 4+.