### PR TITLE
Don't do runtime delegation, delegate explicitly

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -6,8 +6,7 @@ module Draper
     def method_missing(method, *args, &block)
       return super unless delegatable?(method)
 
-      self.class.delegate method
-      send(method, *args, &block)
+      object.send(method, *args, &block)
     end
 
     # Checks if the decorator responds to an instance method, or is able to

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -596,12 +596,16 @@ module Draper
           expect(decorator.hello_world).to be :delegated
         end
 
-        it "adds delegated methods to the decorator when they are used" do
-          decorator = Decorator.new(double(hello_world: :delegated))
+        it "allows calling `super`" do
+          decorator_class = Class.new(Decorator) do
+            def hello_world
+              super and "overriden hello world"
+            end
+          end
+          decorator = Decorator.new(double(hello_world: "hello world"))
 
-          expect(decorator.methods).not_to include :hello_world
-          decorator.hello_world
-          expect(decorator.methods).to include :hello_world
+          expect(decorator.hello_world).to eq "overriden hello world"
+          expect(decorator.hello_world).to eq "overriden hello world"
         end
 
         it "passes blocks to delegated methods" do


### PR DESCRIPTION
If someone accidentally calls `super` instead of `object` inside a decorator, all hell breaks loose.

``` rb
require "draper"
require "ostruct"

class PostDecorator < Draper::Decorator
  delegate_all

  def title
    super and "overriden title"
  end
end

post = OpenStruct.new(title: "title")
decorated_post = PostDecorator.new(post)

puts decorated_post.title #=> "overriden title"
puts decorated_post.title #=> "title"
```

This patch makes both `super` and `object` work. I'm not sure why runtime delegation was added in the first place, but it seems very wrong to add methods on the fly.
