### PR TITLE
Add note on Active Job integration for #663

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,14 @@ ORM](https://github.com/drapergem/draper/wiki/Using-other-ORMs) (including
 versions of Mongoid prior to 3.0), or want to decorate plain old Ruby objects,
 you can include this module manually.
 
+### Active Job Integration
+
+For integration with [Active Job](http://edgeguides.rubyonrails.org/active_job_basics.html), decorated objects will need to implement [Global ID](https://github.com/rails/globalid). Active Job allows you to pass ActiveRecord objects to background tasks directly and performs the necessary serialization and deserialization.  To add Global ID to all Draper decorated objects, add the following code to an initializer (e.g. `config/initializers/draper.rb`):
+
+```ruby
+Draper::Decorator.send(:include, GlobalID::Identification) if defined?(GlobalID)
+```
+
 ## Contributors
 
 Draper was conceived by Jeff Casimir and heavily refined by Steve Klabnik and a


### PR DESCRIPTION
Add a note about Active Job integration which causes Rails serializations issue when passing Draper decorated objects to Rails background mailers.  This patch satisfies issue #663.
