### PR TITLE
rspec-rails ~> 3.2 uses rails_helper fixes #668

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -4,6 +4,6 @@
   require 'spec_helper'
 <% end %>
 
-describe <%= class_name %>Decorator do
+describe <%= class_name %>Decorator, type: :decorator do
   
 end

--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -4,6 +4,6 @@
   require 'spec_helper'
 <% end %>
 
-describe <%= class_name %>Decorator, type: :decorator do
+RSpec.describe <%= class_name %>Decorator, type: :decorator do
   
 end

--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,4 +1,9 @@
-require 'spec_helper'
+<% if RSpec::Rails::Version::STRING.match(/\A3\.[^10]/) %>
+  require 'rails_helper'
+<% else %>
+  require 'spec_helper'
+<% end %>
 
 describe <%= class_name %>Decorator do
+  
 end


### PR DESCRIPTION
As of rspec-rails 3.2 they generate two files:

  - spec/spec_helper.rb
  - spec/rails_helper.rb

This allows the user to either do pure ruby unit tests or include the entire rails environment. Draper really only works in a rails application if it has the rails environment. This matches ~> 3.2 and uses the rails_helper instead of spec_helper.