### PR TITLE
Update version in installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Decorators are the ideal place to:
 Add Draper to your Gemfile:
 
 ```ruby
-gem 'draper', '~> 1.3'
+gem 'draper', '~> 2.1'
 ```
 
 And run `bundle install` within your app's directory.


### PR DESCRIPTION
The installation section of the README currently instructs users to add `gem 'draper', '~> 1.3'` to their Gemfile. The current version of Draper is 2.1 and it might be better to encourage users to use it.