### PR TITLE
Update README to show usage of Draper::ViewContext.controller in RSpec + Engine Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,15 @@ In your `Spork.prefork` block of `spec_helper.rb`, add this:
 require 'draper/test/rspec_integration'
 ```
 
+#### Custom Draper Controller ViewContext
+If running tests in an engine setting with a controller other than "ApplicationController," set a custom controller in `spec_helper.rb`
+
+```ruby
+config.before(:each, type: :decorator) do |example|
+  Draper::ViewContext.controller = ExampleEngine::CustomRootController.new
+end
+```
+
 ### Isolated Tests
 
 In tests, Draper needs to build a view context to access helper methods. By


### PR DESCRIPTION
We are currently developing an engine-only style app. To keep things integration tested, we have the entire spec suite being ran as one. It took a while, but I finally found Draper::ViewContext.controller.

Problem:
I was unable to access any of the route helpers that rails provides via the view_context / `h`

```bash
Failure/Error: decorated.form_url
NoMethodError:
    undefined method `some_named_path' for #<#<Class:0x007fc891d6e7d0>:0x007fc8a6347b70>
# /Users/xxx/.rvm/gems/ruby-2.1.2/gems/draper-2.1.0/lib/draper/helper_proxy.rb:35:in `block in define_proxy'
```

Solution:

In an RSpec config block:

```ruby
config.before(:each, type: :decorator) do |example|
  Draper::ViewContext.controller = ExampleEngine::CustomRootController.new
end
```

Can optionally add a further check to only include a specific path if doing the multiple engines.

```ruby
config.before(:each, type: :decorator) do |example|
  if example.file_path =~ %r{engines/example_engine/spec}
    Draper::ViewContext.controller = ExampleEngine::CustomRootController.new
  end
end
```