### PR TITLE
Improve spec generator template

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
 
-describe <%= class_name %>Decorator do
+RSpec.describe <%= class_name %>Decorator, type: :decorator do
+  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Newer RSpec versions requires that you call the first describe block on the RSpec class.

I also added the type of the spec and a "pending" message, to make it similar to the default rspec generators.

I kept `spec_helper` instead of `rails_helper` because there's no need to load Rails to test the decorator in isolation, since we can test them with POROs and/or stubbing methods.