### PR TITLE
Updating generator to work for Rails 4

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe <%= class_name %>Decorator do
 end


### PR DESCRIPTION
When I used the generator I noticed it broke my test suite because it used spec_helper instead of rails_helper