### PR TITLE
Fix bug in respond_to?

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -7,7 +7,11 @@ module Draper
       return super unless delegatable?(method)
 
       self.class.delegate method
-      send(method, *args, &block)
+      send(method, *args, &block).tap do
+        self.class.class_eval do
+          remove_method method
+        end
+      end
     end
 
     # Checks if the decorator responds to an instance method, or is able to

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -596,14 +596,6 @@ module Draper
           expect(decorator.hello_world).to be :delegated
         end
 
-        it "adds delegated methods to the decorator when they are used" do
-          decorator = Decorator.new(double(hello_world: :delegated))
-
-          expect(decorator.methods).not_to include :hello_world
-          decorator.hello_world
-          expect(decorator.methods).to include :hello_world
-        end
-
         it "passes blocks to delegated methods" do
           object = Model.new
           object.stub(:hello_world) { |*args, &block| block.call }
@@ -678,6 +670,15 @@ module Draper
           decorator = Decorator.new(double(hello_world: :delegated))
 
           expect(decorator).to respond_to :hello_world
+        end
+
+        it "does not incorrectly return true just because it returned true for another object that defined that method" do
+          decorator = Decorator.new(double(hello_world: :delegated))
+          expect(decorator).to respond_to :hello_world
+          decorator.hello_world
+
+          decorator = Decorator.new(double)
+          expect(decorator).to_not respond_to :hello_world
         end
 
         context "with include_private" do


### PR DESCRIPTION
When you call an automatically delegated method on a decorator object, it causes the new method to
remain permanently defined on the decorator class, which causes subsequent calls to `respond_to?` to always return `true` even when the current delegated-to object does not actually respond to that
message.

For example:
```
class A
  def method_on_a
  end
end
class B
end

decorator = Decorator.new(A.new)
decorator.respond_to?(:method_on_a) # => true # as expected
decorator.method_on_a
decorator = Decorator.new(B.new)
decorator.respond_to?(:method_on_a) # => true # incorrect!!
```

This can be very confusing and frustrating if your application uses the same decorator for several different decoratable classes and depends on `respond_to?` to accurately reflect what the underlying decoratable object actually responds to.

I don't yet fully understand what causes this behavior, but it's something to do with the automatic delegation. I added a new test for this and was able to get it passing by adding a `remove_method` after the `delegate` and `send`. This is probably not the best solution, and may have unintended side effects, but I'm currently at a loss how else to solve this.