### PR TITLE
Rails 5 compatibility (rails/test_unit/railtie and ActionController::TestRequest.create)

### DIFF
--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -1,6 +1,7 @@
 require 'rake/testtask'
 
-test_task = if Rails.version.to_f < 3.2
+rails_version = Rails.version.to_f
+test_task = if rails_version < 3.2 || rails_version > 4.2
   require 'rails/test_unit/railtie'
   Rake::TestTask
 else

--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -38,7 +38,13 @@ module Draper
 
         def controller
           (Draper::ViewContext.controller || ApplicationController.new).tap do |controller|
-            controller.request ||= ActionController::TestRequest.new if defined?(ActionController::TestRequest)
+            if defined?(ActionController::TestRequest)
+              controller.request ||= if ActionController::TestRequest.respond_to?(:create)
+                ActionController::TestRequest.create
+              else
+                ActionController::TestRequest.new
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Hi there, Happy New Year to y'all!

Together with the suggestion in https://github.com/drapergem/draper/issues/697 of adding `gem 'activemodel-serializers-xml', git: 'https://github.com/rails/activemodel-serializers-xml'` to my `Gemfile` these to commits/changes made `draper` work on `rails v5.0.0.beta1`.

I suppose this being merged would also fix https://github.com/drapergem/draper/issues/698 and https://github.com/drapergem/draper/issues/681, both of which I sadly just discovered... (poor me ;))

PS:
I tried to set this up to actually run the test suite against the Rails beta on TravisCI, but did not quiet succeed. Have a look at https://github.com/janraasch/draper/commit/92b1b1e8dac19508689eb19052764634a76ddee1 to see where I left off. The main remaining problems are the incompatibilities of required gems in `mongoid` and `minitest-rails`.