### PR TITLE
Allow to call #super inside decorator

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -6,8 +6,12 @@ module Draper
     def method_missing(method, *args, &block)
       return super unless delegatable?(method)
 
-      self.class.delegate method
-      send(method, *args, &block)
+      if self.class.method_defined?(method)
+        object.send(method, *args, &block)
+      else
+        self.class.delegate(method)
+        send(method, *args, &block)
+      end
     end
 
     # Checks if the decorator responds to an instance method, or is able to

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -640,6 +640,17 @@ module Draper
           expect{decorator.hello_world}.to raise_error NoMethodError
           expect(decorator.methods).not_to include :hello_world
         end
+
+        it "allows calling `super`" do
+          decorator = Class.new(Decorator) do
+            def hello_world
+              super and "overriden hello world"
+            end
+          end.new(double(hello_world: "hello world"))
+
+          expect(decorator.hello_world).to eq "overriden hello world"
+          expect(decorator.hello_world).to eq "overriden hello world"
+        end
       end
 
       context ".method_missing" do


### PR DESCRIPTION
``` ruby
class Post
  def title
    "calling super from A to Z"
  end
end

class PostDecorator < Draper::Decorator
  delegate_all

  def title
    super.upcase
  end
end

post = PostDecorator.new(Post.new)
post.title #=> "CALLING SUPER FROM A TO Z"
post.title #=> "calling super from A to Z"
```

This commit fixes the issue, so you can safely call super inside overriden method. 
