### PR TITLE
Implement #deep_dup

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -232,6 +232,13 @@ module Draper
       object.attributes.select {|attribute, _| respond_to?(attribute) }
     end
 
+    # @return [Decorator] a deep_dup of self, decorating a deep_dup of the object
+    def deep_dup
+      self.dup.tap do |dupe|
+        dupe.object = object.deep_dup
+      end
+    end
+
     # ActiveModel compatibility
     delegate :to_param, :to_partial_path
 
@@ -246,6 +253,10 @@ module Draper
       raise if name && !error.missing_name?(name)
       Draper::CollectionDecorator
     end
+
+    protected
+
+    attr_writer :object
 
     private
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -486,6 +486,18 @@ module Draper
       end
     end
 
+    describe "#deep_dup" do
+      it "returns a deep_dup of the decorator and a deep_dup of its object" do
+        obj       = double
+        duped_obj = double
+        decorator = Decorator.new(obj)
+
+        expect(obj).to receive(:deep_dup).and_return(duped_obj)
+        duped_decorator = decorator.deep_dup
+        expect(duped_decorator.object).to eq(duped_obj)
+      end
+    end
+
     describe ".model_name" do
       it "delegates to the source class" do
         Decorator.stub object_class: double(model_name: :delegated)


### PR DESCRIPTION
`Decorator#deep_dup` `dup`-s the decorator and `deep_dup`s its `object`.

Any interest?

One drawback of this approach is that I've had to add a (protected) setter for `object` onto `Decorator`. Perhaps there's a neater way of getting the same result?
