### PR TITLE
Fixed wrong spec

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -78,7 +78,7 @@ module Draper
         if superclass.respond_to?(:decorator_class)
           superclass.decorator_class
         else
-          raise unless error.missing_name?(decorator_name)
+          raise unless error.missing_name?(decorator_name) || error.missing_name?("Object::#{decorator_name}")
           raise Draper::UninferrableDecoratorError.new(self)
         end
       end

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-require 'rails'
-require 'ammeter/init'
+require 'support/generator_support'
 require 'generators/controller_override'
 require 'generators/rails/decorator_generator'
 

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-require 'rails'
-require 'ammeter/init'
+require 'support/generator_support'
 require 'generators/rails/decorator_generator'
 
 describe Rails::Generators::DecoratorGenerator do

--- a/spec/support/generator_support.rb
+++ b/spec/support/generator_support.rb
@@ -1,0 +1,3 @@
+require 'rails'
+Rails.application = Class.new(Rails::Application)
+require 'ammeter/init'


### PR DESCRIPTION
Fix a test that sometimes fail.
- If symbol is not defined, raise NameError as prefixed with `Object::` https://gist.github.com/alpaca-tc/c10348177f5adb4dc0b0 (only Ruby 2.3.0)
- Set `Rails.root` automatically
