### PR TITLE
Remove loading test code when loading draper.

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -16,11 +16,6 @@ module Draper
 
     config.after_initialize do |app|
       app.config.paths.add 'app/decorators', eager_load: true
-
-      if Rails.env.test?
-        require 'draper/test_case'
-        require 'draper/test/rspec_integration' if defined?(RSpec) and RSpec.respond_to?(:configure)
-      end
     end
 
     initializer "draper.setup_action_controller" do |app|


### PR DESCRIPTION
@drock https://github.com/drapergem/draper/issues/704

Removed 
      if Rails.env.test?
        require 'draper/test_case'
        require 'draper/test/rspec_integration' if defined?(RSpec) and RSpec.respond_to?(:configure)
      end
