### PR TITLE
Adding collection_decorator_class to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,19 @@ omitted.
 delegate :current_page, :per_page, :offset, :total_entries, :total_pages
 ```
 
+If needed, you can then set the collection_decorator_class of your CustomDecorator as follows:
+```ruby
+class ArticleDecorator < Draper::Decorator
+  def self.collection_decorator_class
+    PaginatingDecorator
+  end
+end
+
+ArticleDecorator.decorate_collection(@articles.paginate)
+# => Collection decorated by PaginatingDecorator
+# => Members decorated by ArticleDecorator
+```
+
 ### Decorating Associated Objects
 
 You can automatically decorate associated models when the primary model is


### PR DESCRIPTION
Adding how to use a PaginatingDecorator (extending Draper::CollectionDecorator) on a class extending Draper::Decorator to README.md
This explains how to use ArticleDecorator.decorate_collection(@articles.paginate(page: params[:page])) and have your @articles respond to pagination methods whilst individual articles get decorated