### PR TITLE
Add activemodel-serializers-xml gem dependency

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack', '>= 3.0'
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'activemodel', '>= 3.0'
+  s.add_dependency 'activemodel-serializers-xml', '>= 1.0'
 
   s.add_development_dependency 'ammeter'
   s.add_development_dependency 'rake', '>= 0.9.2'


### PR DESCRIPTION
As follows from here: https://github.com/drapergem/draper/issues/697
XML serializers were extracted from rails, and Rails 5 app can't start anymore.

Additionally fixes specs and adds rails 5 branch