### PR TITLE
Fixed deprecation warning: before_filter will be removed in Rails 5.1

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -32,8 +32,8 @@ module Draper
       include Draper::ViewContext
       extend  Draper::HelperSupport
       extend  Draper::DecoratesAssigned
-
-      before_filter :activate_draper
+      
+      public_send(respond_to?(:before_action) ? :before_action : :before_filter, :activate_draper)
     end
   end
 


### PR DESCRIPTION
Gets rid of deprecation warning for before_filter while providing a fallback for old Rails versions.
