### PR TITLE
Prevent automatically delegated methods from piling up on Decorator class.

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -6,7 +6,7 @@ module Draper
     def method_missing(method, *args, &block)
       return super unless delegatable?(method)
 
-      self.class.delegate method
+      self.singleton_class.delegate method
       send(method, *args, &block)
     end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -604,6 +604,14 @@ module Draper
           expect(decorator.methods).to include :hello_world
         end
 
+        it "allows decorator to decorate different classes of objects" do
+          decorator_1 = Decorator.new(double)
+          decorator_2 = Decorator.new(double(hello_world: :delegated))
+
+          decorator_2.hello_world
+          expect(decorator_1.methods).not_to include :hello_world
+        end
+
         it "passes blocks to delegated methods" do
           object = Model.new
           object.stub(:hello_world) { |*args, &block| block.call }


### PR DESCRIPTION
This should be a simple and safe way to prevent the issue described in _Pull Request_ #708 .

Decorator classes are used to wrap all sorts of objects of different classes, and right now, delegate methods are added permanently to the original Decorator class, making the code believe that the decorated object can `respond_to?` a lot of things, but when time comes to call the methods, they are not really there, and everything comes crashing down.

Adding delegates to the `singleton_class` should fix the issue, without undesirable side effects.