### PR TITLE
Extend the "Proxying Class Methods" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ end
 
 This is only necessary when proxying class methods.
 
+Once this association between the decorator and the model is set up, you can call `SomeModel.decorator_class` to access class methods defined in the decorator. If necessary, you can check if your model is decorated with `SomeModel.decorator_class?`.
+
 ### Making Models Decoratable
 
 Models get their `decorate` method from the `Draper::Decoratable` module, which


### PR DESCRIPTION
Quick addition to the readme to explain how to access class methods defined on the decorator when an association with the model has been set up correctly.