### PR TITLE
Update bundler to work with rubygems 2.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.1.5
   - 2.2.1
 
+before_install:
+ - gem update bundler
+
 env:
   - "RAILS_VERSION=4.0"
   - "RAILS_VERSION=4.1"


### PR DESCRIPTION
Fixes undefined method `spec' for nil:NilClass

See https://github.com/bundler/bundler/issues/3558 for more details