### PR TITLE
Fix before_filter deprecation warning

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -33,7 +33,7 @@ module Draper
       extend  Draper::HelperSupport
       extend  Draper::DecoratesAssigned
 
-      before_filter :activate_draper
+      before_action :activate_draper
     end
   end
 


### PR DESCRIPTION
I'm not sure why it keeps pulling in the other two commits. I forked and worked off of the rails-5 branch.