### PR TITLE
add compatibility with latest rails 5.1

### DIFF
--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -38,8 +38,16 @@ module Draper
 
         def controller
           (Draper::ViewContext.controller || ApplicationController.new).tap do |controller|
-            controller.request ||= ActionController::TestRequest.create
+            controller.request ||= new_test_request controller
           end
+        end
+
+        def new_test_request(controller)
+          is_above_rails_5_1 ? ActionController::TestRequest.create(controller) : ActionController::TestRequest.create
+        end
+
+        def is_above_rails_5_1
+          ActionController::TestRequest.method(:create).parameters.first == [:req, :controller_class]
         end
       end
 

--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -46,6 +46,23 @@ module Draper
         expect(controller.view_context.params).to be controller.params
       end
 
+      it "compatible with rails 5.1 change on ActionController::TestRequest.create method" do
+        ActionController::TestRequest.class_eval do
+          if ActionController::TestRequest.method(:create).parameters.first == []
+            def create controller_class
+              create
+            end
+          end
+        end
+        controller = Class.new(ActionController::Base).new
+        allow(ViewContext).to receive_messages controller: controller
+        strategy = ViewContext::BuildStrategy::Full.new
+
+        expect(controller.request).to be_nil
+        strategy.call
+        expect(controller.request).to be_an ActionController::TestRequest
+      end
+
       it "adds methods to the view context from the constructor block" do
         allow(ViewContext).to receive(:controller).and_return(fake_controller)
         strategy = ViewContext::BuildStrategy::Full.new do


### PR DESCRIPTION
Hi,
the latest rails 5.1 changed the "ActionController::TestRequest.create" method by adding one parameter.

https://github.com/rails/rails/pull/26092

so, with latest rails , I got:

```
actionpack/lib/action_controller/test_case.rb:38:in `create': wrong number of arguments (given 0, expected 1) (ArgumentError)
```

in order to keep updated with latest rails and compatible with current 5.0, I made this PR.

Hope it can help.
