### PR TITLE
Add undecorate_chain feature

### DIFF
--- a/lib/draper/undecorate.rb
+++ b/lib/draper/undecorate.rb
@@ -6,4 +6,12 @@ module Draper
       object
     end
   end
+  
+  def self.undecorate_chain(object)
+    if object.respond_to?(:decorated?) && object.decorated?
+      undecorate_chain(object.object)
+    else
+      object
+    end
+  end
 end

--- a/spec/draper/undecorate_chain_spec.rb
+++ b/spec/draper/undecorate_chain_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Draper, '.undecorate_chain' do
+  let!(:object) { Model.new }
+  let!(:decorated_inner) { Class.new(Draper::Decorator).new(object) }
+  let!(:decorated_outer) { Class.new(Draper::Decorator).new(decorated_inner) }
+
+  it 'undecorates full chain of decorated objects' do
+    expect(Draper.undecorate_chain(decorated_outer)).to equal object
+  end
+
+  it 'passes a non-decorated object through' do
+    expect(Draper.undecorate_chain(object)).to equal object
+  end
+
+  it 'passes a non-decorator object through' do
+    object = Object.new
+    expect(Draper.undecorate_chain(object)).to equal object
+  end
+end


### PR DESCRIPTION
Often I need method to fully undecorate object. For example, I want to get purely `baz` from `decorated_baz = FooDecorator.new(BarDecorator.new(baz))`.
