### PR TITLE
Use non-monkey patch describe in generators.

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,4 +1,4 @@
 require 'rails_helper'
 
-describe <%= class_name %>Decorator do
+RSpec.describe <%= class_name %>Decorator do
 end


### PR DESCRIPTION
The default Rails spec generators should not use the monkey patched version of
describe. (https://github.com/rspec/rspec-rails/pull/1052)
