### PR TITLE
Bugfix for missing ActionController::TestRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Draper Changelog
 
+* Fixed a bug where helpers were used inside a decorator and this decorator was used outside of controller context
+
 ## 3.0.0.pre1 - 2016-07-10
 
 * Added support for Rails 5, dropped 4.0 - 4.2

--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -38,7 +38,7 @@ module Draper
 
         def controller
           (Draper::ViewContext.controller || ApplicationController.new).tap do |controller|
-            controller.request ||= new_test_request controller
+            controller.request ||= new_test_request controller if defined?(ActionController::TestRequest)
           end
         end
 


### PR DESCRIPTION
Fixed a bug where helpers were used inside a decorator and this decorator was used outside of controller context.