### PR TITLE
Fix wrong UninferrableDecoratorError error raising

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -74,10 +74,10 @@ module Draper
         decorator_name = "#{prefix}Decorator"
         decorator_name.constantize
       rescue NameError => error
+        raise unless error.missing_name?(decorator_name)
         if superclass.respond_to?(:decorator_class)
           superclass.decorator_class
         else
-          raise unless error.missing_name?(decorator_name)
           raise Draper::UninferrableDecoratorError.new(self)
         end
       end

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -182,6 +182,15 @@ module Draper
         end
       end
 
+      context "when the decorator contains name error" do
+        it "throws an NameError" do
+          # We imitate ActiveSupport::Autoload behavior here in order to cause lazy NameError exception raising
+          allow_any_instance_of(Module).to receive(:const_missing) { Class.new { any_nonexisting_method_name } }
+
+          expect{Model.decorator_class}.to raise_error { |error| expect(error).to be_an_instance_of(NameError) }
+        end
+      end
+
       context "when the decorator can't be inferred" do
         it "throws an UninferrableDecoratorError" do
           expect{Model.decorator_class}.to raise_error UninferrableDecoratorError


### PR DESCRIPTION
Rescue in .decorator_class falsely catches genuine NameError

Within `./draper_test.rb`:
```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails"
  gem "activemodel-serializers-xml"
  gem "sqlite3"
  gem "draper"
end

require "rails"
require "activemodel-serializers-xml"
require "draper"
require "minitest/autorun"

class DummyApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.autoload_paths << File.dirname(__FILE__)
  config.session_store :cookie_store, key: "cookie_store_key"
  secrets.secret_token    = "secret_token"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
end
Rails.initialize!

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define { create_table :users, force: true }
User = Class.new(ActiveRecord::Base)

class BugTest < Minitest::Test
  def test_raise_name_error
    error = assert_raises(NameError) { User.new.decorate }
    assert_instance_of NameError, error
  end

  def test_raise_error_on_undefined
    error = assert_raises(NameError) { User.new.decorate }
    assert_match /undefined local variable or method/, error.message
  end
end
```

`./user_decorator.rb`:
```ruby
class UserDecorator < Draper::Decorator
  any_nonexisting_method_name
end
```

Output:
```
# Running:

FF

Finished in 0.005504s, 363.3456 runs/s, 908.3641 assertions/s.

  1) Failure:
BugTest#test_raise_error_on_undefined [draper.rb:45]:
Expected /undefined local variable or method/ to match "Could not infer a decorator for ActiveRecord::Base.".


  2) Failure:
BugTest#test_raise_name_error [draper.rb:40]:
Expected #<Draper::UninferrableDecoratorError: Could not infer a decorator for ActiveRecord::Base.> to be an instance of NameError, not Draper::UninferrableDecoratorError.

2 runs, 5 assertions, 2 failures, 0 errors, 0 skips
```