### PR TITLE
minor fix to error raising on collection decoration.

### DIFF
--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -231,7 +231,7 @@ module Draper
       name = collection_decorator_name
       name.constantize
     rescue NameError => error
-      raise if name && !error.missing_name?(name)
+      raise if name && !name.include?(error.missing_name)
       Draper::CollectionDecorator
     end
 


### PR DESCRIPTION
The previous version raised an error with eager loaded classes in case one had say a model class with the same name as the decorator module and trying to decorate a collection. 
E.g. having an `Article` model, an `Article::AuthorCredential` model and an `Article::AuthorCredentialDecorator` would raise a NameError when trying to do `Article::AuthorCredential.all.decorate`.
This fix eliminates the problem