### PR TITLE
Support Rails 5 API-only apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ And run `bundle install` within your app's directory.
 If you're upgrading from a 0.x release, the major changes are outlined [in the
 wiki](https://github.com/drapergem/draper/wiki/Upgrading-to-1.0).
 
+### Rails 5 API-only compatibility
+
+Draper expects your `ApplicationController` to include `ActionView::Rendering`.  However, Rails 5 API-only applications (created with `rails new --api`) don't by default.  However, including `ActionView::Rendering` in ApplicatonController also breaks `render :json`.  Therefore, you use an alternate controller by adding the following to your `application.rb`:
+
+```ruby
+draper__view_context = ::Draper::ViewContext
+def draper__view_context.controller
+  Class.new(ApplicationController) { include ActionView::Rendering }.new
+end
+
+```
+
 ## Writing Decorators
 
 Decorators inherit from `Draper::Decorator`, live in your `app/decorators`

--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -51,7 +51,7 @@ module Draper
 
     console do
       require 'action_controller/test_case'
-      controller = ApplicationController.new
+      controller = (Draper::ViewContext.controller || ApplicationController.new)
       controller.view_context if controller.respond_to? :view_context
       Draper::ViewContext.build
     end


### PR DESCRIPTION
This is a partial fix for #753 and #754.  Including `ActionView::Rendering` in `ApplicationController` fixes the `view_context` `NoMethodError`.  However, doing so currently breaks any actions which use `render :json` (may be a Rails bug, see rails/rails#27211).  This PR allows an alternate controller to be used by Draper so that ApplicationController is not affected.

I'm aware that this is a hackish solution, and I'm hoping that the Rails issue will be fixed and make this PR mostly irrelevant.  But I'm creating this here because it does work for us in the mean time and it may lead to a better understanding of the problem and a cleaner solution.