### PR TITLE
Rename UninferrableSourceError to UninferrableObjectError

### DIFF
--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -55,9 +55,11 @@ module Draper
     end
   end
 
-  class UninferrableSourceError < NameError
+  class UninferrableObjectError < NameError
     def initialize(klass)
-      super("Could not infer a source for #{klass}.")
+      super("Could not infer an object for #{klass}.")
     end
   end
+
+  UninferrableSourceError = UninferrableObjectError # TODO: deprecate this
 end

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -72,7 +72,7 @@ module Draper
     # Checks whether this decorator class has a corresponding {object_class}.
     def self.object_class?
       object_class
-    rescue Draper::UninferrableSourceError
+    rescue Draper::UninferrableObjectError
       false
     end
 
@@ -256,7 +256,7 @@ module Draper
       name.constantize
     rescue NameError => error
       raise if name && !error.missing_name?(name)
-      raise Draper::UninferrableSourceError.new(self)
+      raise Draper::UninferrableObjectError.new(self)
     end
 
     def self.collection_decorator_name

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -181,21 +181,25 @@ module Draper
       protect_class Namespaced::ProductDecorator
 
       context "when not set by .decorates" do
-        it "raises an UninferrableSourceError for a so-named 'Decorator'" do
+        it "raises an UninferrableObjectError for a so-named 'Decorator'" do
+          expect{Decorator.object_class}.to raise_error UninferrableObjectError
+        end
+
+        it "supports UninferrableSourceError alias for a backward compatibility" do
           expect{Decorator.object_class}.to raise_error UninferrableSourceError
         end
 
-        it "raises an UninferrableSourceError for anonymous decorators" do
-          expect{Class.new(Decorator).object_class}.to raise_error UninferrableSourceError
+        it "raises an UninferrableObjectError for anonymous decorators" do
+          expect{Class.new(Decorator).object_class}.to raise_error UninferrableObjectError
         end
 
-        it "raises an UninferrableSourceError for a decorator without a model" do
+        it "raises an UninferrableObjectError for a decorator without a model" do
           skip
-          expect{OtherDecorator.object_class}.to raise_error UninferrableSourceError
+          expect{OtherDecorator.object_class}.to raise_error UninferrableObjectError
         end
 
-        it "raises an UninferrableSourceError for other naming conventions" do
-          expect{ProductPresenter.object_class}.to raise_error UninferrableSourceError
+        it "raises an UninferrableObjectError for other naming conventions" do
+          expect{ProductPresenter.object_class}.to raise_error UninferrableObjectError
         end
 
         it "infers the source for '<Model>Decorator'" do
@@ -227,7 +231,7 @@ module Draper
       end
 
       it "returns false when .object_class is not inferrable" do
-        allow(Decorator).to receive(:object_class).and_raise(UninferrableSourceError.new(Decorator))
+        allow(Decorator).to receive(:object_class).and_raise(UninferrableObjectError.new(Decorator))
 
         expect(Decorator.object_class?).to be_falsey
       end


### PR DESCRIPTION
Since source has been renamed to object, it is better for consistency to have UninferrableObjectError class name with the error message mentioning 'object' property instead of 'source'.