### PR TITLE
Fix issue with decoratable class equality operator

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -86,7 +86,11 @@ module Draper
       #
       # @return [Boolean]
       def ===(other)
-        super || (other.respond_to?(:object) && super(other.object))
+        super || (
+          other.respond_to?(:object) &&
+            [-1, 0].include?(other.method(:object).arity) &&
+            super(other.object)
+        )
       end
 
     end

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -125,6 +125,18 @@ module Draper
 
         expect(Product === decorator).to be_falsey
       end
+
+      it "is false for a class instance requiring arguments to `object` method" do
+        class ArgsObject; def object(_foo); Product.new end; end
+
+        expect(Product === ArgsObject.new).to be_falsey
+      end
+
+      it "is true for a class instance requiring variable arguments to `object` method" do
+        class VarArgsObject; def object(*_foo); Product.new; end; end
+
+        expect(Product === VarArgsObject.new).to be_truthy
+      end
     end
 
     describe ".decorate" do


### PR DESCRIPTION
If you try compare a decorated class with an object that responds to object *but requires arguments*, the overridden class equality operator will cause an exception to be raised. This change requires that the `other` object method arity be 0 (no args) or -1 (any number of args)

The specific place where I've found this to be an issue is when using the rspec `(expect|allow)_any_instance_of` method and passing it an ActiveRecord model in combination with the redis gem (where the redis client class responds to object but requires an argument). Rspec tries to set up its mock proxies where it then compares the AR class to the redis instance. *doh*

I've included a spec that validates that the operator now just returns false for that use case
