### PR TITLE
Fix deprecations and possible false positive issue in tests.

### DIFF
--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -39,7 +39,7 @@ module Draper
         expect(controller.request).to be_nil
         strategy.call
         expect(controller.request).to be_an ActionController::TestRequest
-        expect(controller.params).to eq({})
+        expect(controller.params.to_h).to eq({})
 
         # sanity checks
         expect(controller.view_context.request).to be controller.request

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -2,4 +2,4 @@ require 'rubygems'
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/spec/dummy/fast_spec/post_decorator_spec.rb
+++ b/spec/dummy/fast_spec/post_decorator_spec.rb
@@ -32,6 +32,6 @@ describe PostDecorator do
   end
 
   it "can't be passed implicitly to url_for" do
-    expect{decorator.link}.to raise_error
+    expect{decorator.link}.to raise_error ArgumentError
   end
 end


### PR DESCRIPTION
This pull request fixes a couple deprecations. One of which will be removed in Rails 5.1.

The deprecations are:

DEPRECATION WARNING: Comparing equality between `ActionController::Parameters` and a `Hash` is deprecated and will be removed in Rails 5.1. Please only do comparisons between instances of `ActionController::Parameters`. If you need to compare to a hash, first convert it using `ActionController::Parameters#new`. (called from block (3 levels) in <module:Draper> at /Users/cliff/Code/drapergem/draper/spec/draper/view_context/build_strategy_spec.rb:42)

/Users/cliff/Code/drapergem/draper/spec/dummy/config/boot.rb:5: warning: File.exists? is a deprecated name, use File.exist? instead

Possible false positive in tests:

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: arguments passed to url_for can't be handled. Please require routes or provide your own implementation>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/cliff/Code/codebycliff/draper/spec/dummy/fast_spec/post_decorator_spec.rb:35:in `block (2 levels) in <top (required)>