### PR TITLE
Remove previously deprecated functionality.

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -42,17 +42,7 @@ module Draper
       @decorated_collection ||= object.map{|item| decorate_item(item)}
     end
 
-    # Delegated to the decorated collection when using the block form
-    # (`Enumerable#find`) or to the decorator class if not
-    # (`ActiveRecord::FinderMethods#find`)
-    def find(*args, &block)
-      if block_given?
-        decorated_collection.find(*args, &block)
-      else
-        ActiveSupport::Deprecation.warn("Using ActiveRecord's `find` on a CollectionDecorator is deprecated. Call `find` on a model, and then decorate the result", caller)
-        decorate_item(object.find(*args))
-      end
-    end
+    delegate :find, to: :decorated_collection
 
     def to_s
       "#<#{self.class.name} of #{decorator_class || "inferred decorators"} for #{object.inspect}>"

--- a/lib/draper/helper_proxy.rb
+++ b/lib/draper/helper_proxy.rb
@@ -4,9 +4,7 @@ module Draper
   class HelperProxy
 
     # @overload initialize(view_context)
-    def initialize(view_context = nil)
-      view_context ||= current_view_context # backwards compatibility
-
+    def initialize(view_context)
       @view_context = view_context
     end
 
@@ -34,11 +32,6 @@ module Draper
       define_method name do |*args, &block|
         view_context.send(name, *args, &block)
       end
-    end
-
-    def current_view_context
-      ActiveSupport::Deprecation.warn("wrong number of arguments (0 for 1) passed to Draper::HelperProxy.new", caller[1..-1])
-      Draper::ViewContext.current.view_context
     end
   end
 end

--- a/lib/draper/test/devise_helper.rb
+++ b/lib/draper/test/devise_helper.rb
@@ -1,14 +1,7 @@
 module Draper
   module DeviseHelper
     def sign_in(resource_or_scope, resource = nil)
-      scope = begin
-        Devise::Mapping.find_scope!(resource_or_scope)
-      rescue RuntimeError => e
-        # Draper 1.0 didn't require the mapping to exist
-        ActiveSupport::Deprecation.warn("#{e.message}.\nUse `sign_in :user, mock_user` instead.", caller)
-        :user
-      end
-
+      scope = Devise::Mapping.find_scope!(resource_or_scope)
       _stub_current_scope scope, resource || resource_or_scope
     end
 

--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -82,23 +82,5 @@ module Draper
     def self.build_strategy
       @build_strategy ||= Draper::ViewContext::BuildStrategy.new(:full)
     end
-
-    # @deprecated Use {controller} instead.
-    def self.current_controller
-      ActiveSupport::Deprecation.warn("Draper::ViewContext.current_controller is deprecated (use controller instead)", caller)
-      self.controller || ApplicationController.new
-    end
-
-    # @deprecated Use {controller=} instead.
-    def self.current_controller=(controller)
-      ActiveSupport::Deprecation.warn("Draper::ViewContext.current_controller= is deprecated (use controller= instead)", caller)
-      self.controller = controller
-    end
-
-    # @deprecated Use {build} instead.
-    def self.build_view_context
-      ActiveSupport::Deprecation.warn("Draper::ViewContext.build_view_context is deprecated (use build instead)", caller)
-      build
-    end
   end
 end

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -121,26 +121,11 @@ module Draper
     end
 
     describe "#find" do
-      context "with a block" do
-        it "decorates Enumerable#find" do
-          decorator = CollectionDecorator.new([])
+      it "decorates Enumerable#find" do
+        decorator = CollectionDecorator.new([])
 
-          expect(decorator.decorated_collection).to receive(:find).and_return(:delegated)
-          expect(decorator.find{|p| p.title == "title"}).to be :delegated
-        end
-      end
-
-      context "without a block" do
-        it "decorates object.find" do
-          object = []
-          found = double(decorate: :decorated)
-          decorator = CollectionDecorator.new(object)
-
-          expect(object).to receive(:find).and_return(found)
-          ActiveSupport::Deprecation.silence do
-            expect(decorator.find(1)).to be :decorated
-          end
-        end
+        expect(decorator.decorated_collection).to receive(:find).and_return(:delegated)
+        expect(decorator.find{|p| p.title == "title"}).to be :delegated
       end
     end
 

--- a/spec/dummy/spec/decorators/devise_spec.rb
+++ b/spec/dummy/spec/decorators/devise_spec.rb
@@ -51,14 +51,5 @@ if defined?(Devise)
 
       expect(helper.current_user).to be_nil
     end
-
-    it "is backwards-compatible" do
-      user = double("User")
-      ActiveSupport::Deprecation.silence do
-        sign_in user
-      end
-
-      expect(helper.current_user).to be user
-    end
   end
 end

--- a/spec/dummy/test/decorators/minitest/devise_test.rb
+++ b/spec/dummy/test/decorators/minitest/devise_test.rb
@@ -51,14 +51,5 @@ if defined?(Devise)
 
       assert helper.current_user.nil?
     end
-
-    it "is backwards-compatible" do
-      user = Object.new
-      ActiveSupport::Deprecation.silence do
-        sign_in user
-      end
-
-      assert_same user, helper.current_user
-    end
   end
 end

--- a/spec/dummy/test/decorators/test_unit/devise_test.rb
+++ b/spec/dummy/test/decorators/test_unit/devise_test.rb
@@ -51,14 +51,5 @@ if defined?(Devise)
 
       assert helper.current_user.nil?
     end
-
-    def test_backwards_compatibility
-      user = Object.new
-      ActiveSupport::Deprecation.silence do
-        sign_in user
-      end
-
-      assert_same user, helper.current_user
-    end
   end
 end


### PR DESCRIPTION
This pull request removes all functionality that was previously deprecated. This code was originally in [Support Rails::API controllers](https://github.com/drapergem/draper/pull/754), but I thought it would be best to pull it out into a separate pull request for better tracking.