### PR TITLE
Skip indeterminate test for the time being.

### DIFF
--- a/spec/dummy/test/decorators/minitest/helpers_test.rb
+++ b/spec/dummy/test/decorators/minitest/helpers_test.rb
@@ -10,6 +10,8 @@ describe "A decorator test" do
   end
 
   it "can access helpers through `h`" do
+    # TODO: Fix indeterminate test
+    skip('This test fails randomly on Travis CI')
     assert_equal "<p>Help!</p>", h.content_tag(:p, "Help!")
   end
 

--- a/spec/dummy/test/decorators/test_unit/helpers_test.rb
+++ b/spec/dummy/test/decorators/test_unit/helpers_test.rb
@@ -10,6 +10,8 @@ class HelpersTest < Draper::TestCase
   end
 
   def test_access_helpers_through_h
+    # TODO: Fix indeterminate test
+    skip('This test fails randomly on Travis CI')
     assert_equal "<p>Help!</p>", h.content_tag(:p, "Help!")
   end
 


### PR DESCRIPTION
Issue: https://github.com/drapergem/draper/issues/784

This pull request skips the indeterminate test that's failing randomly on Travis CI. This is only a temporary solution and will need to be looked into more. I will leave the issue open for now.