### PR TITLE
GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,4 @@ Outline steps to test your changes.
 
 ## References
 * [GitHub Issue ####](https://github.com/drapergem/draper/issues/####)
+* [GitHub Pull Request ####](https://github.com/drapergem/draper/pull/####)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+Detail your changes here.  
+A few sentences describing the overall goals of the pull request's commits will suffice.
+Some questions you might answer:
+
+* Why was this change required?
+* Did you have any tough decisions to make? Which one(s) did you go with and why?
+* Are there any deployment impacts to this change?
+* Is there something you aren't happy with or that needs extra attention?
+
+## Testing
+Outline steps to test your changes.
+
+1. Go here.
+1. Click this.
+1. See that.
+
+## To-Dos
+- [ ] tests
+- [ ] documentation
+
+## References
+* [GitHub Issue ####](https://github.com/drapergem/draper/issues/####)


### PR DESCRIPTION
## Description
This branch adds a Markdown document to be used as a template for GitHub pull request descriptions.  The template document will pre-fill into the PR description text editor, allowing the submitter to recognize and provide necessary information in a standard format.  This change will ease maintainers' ability to understand changes by collaborators, helping to streamline the flow of repository changes.

## Testing
Unfortunately, this change will not be testable until it's in the master branch.  At that point, the `.github` directory will be recognized by GitHub which will allow future PRs to use the template.  Additional templates may be added to this directory in the future (see blog post reference link below).

## To-Dos
N/A

## References
* [Issue and Pull Request templates](https://github.com/blog/2111-issue-and-pull-request-templates)
