### PR TITLE
Fix the indeterminate test issue.

### DIFF
--- a/spec/dummy/test/decorators/minitest/view_context_test.rb
+++ b/spec/dummy/test/decorators/minitest/view_context_test.rb
@@ -13,12 +13,12 @@ describe "A decorator test" do
   it_does_not_leak_view_context
 end
 
-describe "A controller test" do
-  subject{ Class.new(ActionController::Base) }
+describe "A controller decorator test" do
+  subject { Class.new(ActionController::Base) }
 
   it_does_not_leak_view_context
 end
 
-describe "A mailer test" do
+describe "A mailer decorator test" do
   it_does_not_leak_view_context
 end


### PR DESCRIPTION
## Description
This pull request fixes the indeterminate test issue causing builds to fail randomly. I finally got to the bottom of what was causing it. The issue was with the minitest spec tests. A couple of the `describe` blocks didn't have the word "decorator" in them. This prevented minitest from registering the spec type as `Draper::TestCase`. Since the tests weren't registered as a `Draper::TestCase`, it wasn't including `Draper::TestCase::ViewContextTeardown` which defines `teardown` to clear the view context. Since the view context wasn't being cleared after these tests, the next test that called a helper on `ViewContext.current` blew up.

## Testing
Once merged, we should not longer see builds fail randomly. You can test locally by:

1. `$ cd spec/dummy`
2. `SEED=8910 rake` should fail repeatedly on master.
3. Switch to this branch and run the above command and the test suite should pass.

## To-Dos
None

## References
* [GitHub Issue 784](https://github.com/drapergem/draper/issues/784)