### PR TITLE
un-skip test and remove unused class definition

### DIFF
--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -190,7 +190,6 @@ module Draper
         end
 
         it "raises an UninferrableObjectError for a decorator without a model" do
-          skip
           expect{OtherDecorator.object_class}.to raise_error UninferrableObjectError
         end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -190,10 +190,12 @@ module Draper
         end
 
         it "raises an UninferrableObjectError for a decorator without a model" do
-          expect{OtherDecorator.object_class}.to raise_error UninferrableObjectError
+          SomeDecorator = Class.new(Draper::Decorator)
+          expect{SomeDecorator.object_class}.to raise_error UninferrableObjectError
         end
 
         it "raises an UninferrableObjectError for other naming conventions" do
+          ProductPresenter = Class.new(Draper::Decorator)
           expect{ProductPresenter.object_class}.to raise_error UninferrableObjectError
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ class Model; include Draper::Decoratable; end
 
 class Product < Model; end
 class SpecialProduct < Product; end
-class Other < Model; end
 class ProductDecorator < Draper::Decorator; end
 class ProductsDecorator < Draper::CollectionDecorator; end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,9 @@ class Model; include Draper::Decoratable; end
 
 class Product < Model; end
 class SpecialProduct < Product; end
+class Other < Model; end
 class ProductDecorator < Draper::Decorator; end
 class ProductsDecorator < Draper::CollectionDecorator; end
-
-class ProductPresenter < Draper::Decorator; end
 
 class OtherDecorator < Draper::Decorator; end
 


### PR DESCRIPTION
## Description
This branch un-skips a test and fixes the underlying reason for skipping it in the first place.  The culprit, a class definition `Other` in the `spec_helper`, was preventing this test from passing.  The build passes after removing this and the `skip` directive and does not affect other tests in the suite.

## Testing
1. Run `rake`.
1. All specs should pass.

## To-Dos
N/A

## References
N/A