### PR TITLE
Add rubocop development dependency and code climate configuration.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,16 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,18 +7,5 @@ AllCops:
 Style/StringLiterals:
   Enabled: false
 
-Style/Documentation:
-  Enabled: false
-
 Metrics/LineLength:
   Max: 100
-
-Metrics/MethodLength:
-  Max: 15
-
-Metrics/AbcSize:
-  Max: 25
-
-Metrics/ClassLength:
-  Max: 120
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,24 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  DisplayCopNames: true
+  Exclude:
+    - 'spec/dummy/**/*'
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/ClassLength:
+  Max: 120
+

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest-rails'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'active_model_serializers', '~> 0.10'
+  s.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
## Description
This pull request adds Code Climate configuration for engine based analysis. It also adds Rubocop as a development dependency. Note, this will decrease our Code Climate score dramatically until we get around to fixing some of the style issues. We can disable certain rules entirely if people feel Code Climate / Rubocop is being too picky. My goal is to get Rubocop added to the rake task / continuous integration, but want to wait until we get a chance to address some of its complaints. 

## Testing
The Code Climate results will show up once this pull request is merged into master. If you want to test rubocop, just bundle and run: `$ rubocop`.

## To-Dos
None

## References
* [GitHub Issue 783](https://github.com/drapergem/draper/issues/783)
