### PR TITLE
Clean view context when controller changes

### DIFF
--- a/lib/draper/view_context.rb
+++ b/lib/draper/view_context.rb
@@ -20,8 +20,10 @@ module Draper
       RequestStore.store[:current_controller]
     end
 
-    # Sets the current controller.
+    # Sets the current controller. Clears view context when we are setting
+    # different controller.
     def self.controller=(controller)
+      clear! if RequestStore.store[:current_controller] != controller
       RequestStore.store[:current_controller] = controller
     end
 

--- a/spec/draper/view_context_spec.rb
+++ b/spec/draper/view_context_spec.rb
@@ -32,6 +32,34 @@ module Draper
         ViewContext.controller = :stored_controller
         expect(store[:current_controller]).to be :stored_controller
       end
+
+      it "cleans context when controller changes" do
+        store = {
+          current_controller: :stored_controller,
+          current_view_context: :stored_view_context
+        }
+
+        allow(RequestStore).to receive_messages store: store
+
+        ViewContext.controller = :other_stored_controller
+
+        expect(store).to include(current_controller: :other_stored_controller)
+        expect(store).not_to include(:current_view_context)
+      end
+
+      it "doesn't clean context when controller is the same" do
+        store = {
+          current_controller: :stored_controller,
+          current_view_context: :stored_view_context
+        }
+
+        allow(RequestStore).to receive_messages store: store
+
+        ViewContext.controller = :stored_controller
+
+        expect(store).to include(current_controller: :stored_controller)
+        expect(store).to include(current_view_context: :stored_view_context)
+      end
     end
 
     describe ".current" do


### PR DESCRIPTION
## Description
When we reassign controller it is the right thing to do to clear current view context stored in request store. Consider a case when view context was built before the request was made (usage of `h` helper in class level context). View context is built from default controller and has no information about the request. During first request `Draper::ViewContext.current.controller` will be different than `Draper::ViewContext.controller`.

## Testing

Example Rails app. Use `h.content_tag` in class context of some decorator, make this class be eagerly loaded.

Perform some request that will execute some decorator to refer to e.g. `request.env` values that are set up by some middleware (e.g. warden manager).

See that `env` is missing that key.

With that fix, view_context is regenerated when a controller is already available.

## To-Dos
- [x] tests
- [x] documentation
