### PR TITLE
Fix failing specs re Rails 5.1

### DIFF
--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -38,7 +38,7 @@ module Draper
         expect(controller.request).to be_nil
         strategy.call
         expect(controller.request).to be_an ActionController::TestRequest
-        expect(controller.params.to_h).to eq({})
+        expect(controller.params).to be_empty
 
         # sanity checks
         expect(controller.view_context.request).to be controller.request

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < BaseController
   def mail
     post = Post.find(params[:id])
     email = PostMailer.decorated_email(post).deliver
-    render text: email.body
+    render html: email.body.to_s.html_safe
   end
 
   private


### PR DESCRIPTION
## Description
Because there is no hard constraint on Rails version, tests run against the newest version available. Rails 5.1 removes `to_h` from unpermitted parameters class. Using `empty?` is a sufficient replacement.

Also, Rails 5.1 does not accept `:text` option for `render`. Using `:html` should do a job.

## Testing

```
rspec ./spec/draper/view_context/build_strategy_spec.rb:33

RAILS_ENV=development rspec spec/integration/integration_spec.rb
```
