### PR TITLE
Revert "Optimization: Optimize CollectionDecorator Enumerable behavior"

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -15,7 +15,7 @@ module Draper
     #   to each item's decorator.
     attr_accessor :context
 
-    array_methods = Array.instance_methods - Object.instance_methods - Enumerable.instance_methods
+    array_methods = Array.instance_methods - Object.instance_methods
     delegate :==, :as_json, *array_methods, to: :decorated_collection
 
     # @param [Enumerable] object
@@ -40,23 +40,6 @@ module Draper
     # @return [Array] the decorated items.
     def decorated_collection
       @decorated_collection ||= object.map{|item| decorate_item(item)}
-    end
-
-    # Optimization to prevent unnecessary iteration (useful for larger collections).
-    # Iterates over the collection, decorating objects as it goes. If the decorated collection is
-    # already set, iterate over it instead.
-    def each(&block)
-      if @decorated_collection
-        @decorated_collection.each(&block)
-      else
-        @decorated_collection = []
-        object.each do |item|
-          decorated_item = decorate_item(item)
-          @decorated_collection << decorated_item
-
-          block.call(decorated_item)
-        end
-      end
     end
 
     delegate :find, to: :decorated_collection

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -288,38 +288,5 @@ module Draper
       end
     end
 
-    describe "#each" do
-      it "iterates over the collection, decorating as it goes" do
-        collection = [Product.new]
-        decorator = CollectionDecorator.new(collection)
-
-        expect(collection).to_not receive(:map)
-        decorator.each { |product| product.decorated? }
-        expect(decorator.instance_variable_get(:@decorated_collection)[0]).to be_decorated
-      end
-
-      it "uses decorated_collection if already set" do
-        decorated_collection = double(:decorated_collection)
-        decorator = CollectionDecorator.new([])
-        decorator.instance_variable_set(:@decorated_collection, decorated_collection)
-
-        expect(decorated_collection).to receive(:each)
-
-        decorator.each
-      end
-    end
-
-    describe "Enumerable methods" do
-      it "doesn't delegate Enumerable methods to its decorated collection" do
-        decorated_collection = double(:decorated_collection)
-        decorator = CollectionDecorator.new([])
-        decorator.instance_variable_set(:@decorated_collection, decorated_collection)
-
-        expect(decorated_collection).to_not receive(:map)
-
-        decorator.map
-      end
-    end
-
   end
 end


### PR DESCRIPTION
I'm reverting this pull request for the time being. It was just a performance optimization to begin with. It caused some issues as noted [in this thread](https://github.com/drapergem/draper/commit/f6a7b17a8acfa7633762d665ab218a6478d32a98). Furthermore, running the benchmarks again are returning inconsistent results. This time around, it's showing the performance being slightly better pre-patch. I'm not sure if this is just do to inconsistencies on my machine or what. Either way, I think this is the safest bet until we can resolve the issues noted above and provide convincing benchmarks.