### PR TITLE
Replace hash rockets with new syntax

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,25 +1,25 @@
 def rspec_guard(options = {}, &block)
   options = {
-    :version => 2,
-    :notification => false
+    version: 2,
+    notification: false
   }.merge(options)
 
   guard 'rspec', options, &block
 end
 
-rspec_guard :spec_paths => %w{spec/draper spec/generators} do
+rspec_guard spec_paths: %w{spec/draper spec/generators} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 end
 
-rspec_guard :spec_paths => 'spec/integration', :env => {'RAILS_ENV' => 'development'} do
+rspec_guard spec_paths: 'spec/integration', env: {'RAILS_ENV' => 'development'} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 end
 
-rspec_guard :spec_paths => 'spec/integration', :env => {'RAILS_ENV' => 'production'} do
+rspec_guard spec_paths: 'spec/integration', env: {'RAILS_ENV' => 'production'} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -2,7 +2,7 @@ require 'rake/testtask'
 require 'rails/test_unit/railtie'
 
 namespace :test do
-  Rake::TestTask.new(:decorators => "test:prepare") do |t|
+  Rake::TestTask.new(decorators: "test:prepare") do |t|
     t.libs << "test"
     t.pattern = "test/decorators/**/*_test.rb"
   end

--- a/lib/generators/mini_test/decorator_generator.rb
+++ b/lib/generators/mini_test/decorator_generator.rb
@@ -7,7 +7,7 @@ module MiniTest
         File.expand_path('../templates', __FILE__)
       end
 
-      class_option :spec, :type => :boolean, :default => false, :desc => "Use MiniTest::Spec DSL"
+      class_option :spec, type: :boolean, default: false, desc: "Use MiniTest::Spec DSL"
 
       check_class_collision suffix: "DecoratorTest"
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,11 +11,11 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121019115657) do
+ActiveRecord::Schema.define(version: 20121019115657) do
 
-  create_table "posts", :force => true do |t|
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+  create_table "posts", force: true do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/dummy/lib/tasks/test.rake
+++ b/spec/dummy/lib/tasks/test.rake
@@ -13,4 +13,4 @@ RSpec::Core::RakeTask.new :fast_spec do |t|
   t.pattern = "fast_spec/**/*_spec.rb"
 end
 
-task :default => [:test, :spec, :fast_spec]
+task default: [:test, :spec, :fast_spec]


### PR DESCRIPTION
## Description
Full replacement of rocket hash syntax with newer, because of rocket hash deprecation. 
