### PR TITLE
Add migration version to create posts migration from dummy app in spec

### DIFF
--- a/spec/dummy/db/migrate/20121019115657_create_posts.rb
+++ b/spec/dummy/db/migrate/20121019115657_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[4.2]
   def change
     create_table :posts do |t|
 


### PR DESCRIPTION
## Description
Rails 5.1 has version number in migrations. 