### PR TITLE
Replace double quotes with single quotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
 platforms :ruby do
-  gem "sqlite3"
+  gem 'sqlite3'
 end
 
 platforms :jruby do
-  gem "minitest"
-  gem "activerecord-jdbcsqlite3-adapter"
+  gem 'minitest'
+  gem 'activerecord-jdbcsqlite3-adapter'
 end
 
-gem "rails", "~> 5.0"
-gem "mongoid", github: "mongodb/mongoid"
+gem 'rails', '~> 5.0'
+gem 'mongoid', github: 'mongodb/mongoid'

--- a/Guardfile
+++ b/Guardfile
@@ -10,17 +10,17 @@ end
 rspec_guard spec_paths: %w{spec/draper spec/generators} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+  watch('spec/spec_helper.rb')  { 'spec' }
 end
 
 rspec_guard spec_paths: 'spec/integration', env: {'RAILS_ENV' => 'development'} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+  watch('spec/spec_helper.rb')  { 'spec' }
 end
 
 rspec_guard spec_paths: 'spec/integration', env: {'RAILS_ENV' => 'production'} do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+  watch('spec/spec_helper.rb')  { 'spec' }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,16 +7,16 @@ def run_in_dummy_app(command)
   raise "#{command} failed" unless success
 end
 
-task "default" => "ci"
+task 'default' => 'ci'
 
-desc "Run all tests for CI"
-task "ci" => "spec"
+desc 'Run all tests for CI'
+task 'ci' => 'spec'
 
-desc "Run all specs"
-task "spec" => "spec:all"
+desc 'Run all specs'
+task 'spec' => 'spec:all'
 
-namespace "spec" do
-  task "all" => ["draper", "generators", "integration"]
+namespace 'spec' do
+  task 'all' => ['draper', 'generators', 'integration']
 
   def spec_task(name)
     desc "Run #{name} specs"
@@ -25,45 +25,45 @@ namespace "spec" do
     end
   end
 
-  spec_task "draper"
-  spec_task "generators"
+  spec_task 'draper'
+  spec_task 'generators'
 
-  desc "Run integration specs"
-  task "integration" => ["db:setup", "integration:all"]
+  desc 'Run integration specs'
+  task 'integration' => ['db:setup', 'integration:all']
 
-  namespace "integration" do
-    task "all" => ["development", "production", "test"]
+  namespace 'integration' do
+    task 'all' => ['development', 'production', 'test']
 
-    ["development", "production"].each do |environment|
+    ['development', 'production'].each do |environment|
       task environment do
-        Rake::Task["spec:integration:run"].execute environment
+        Rake::Task['spec:integration:run'].execute environment
       end
     end
 
-    task "run" do |t, environment|
+    task 'run' do |t, environment|
       puts "Running integration specs in #{environment}"
 
-      ENV["RAILS_ENV"] = environment
-      success = system("rspec spec/integration")
+      ENV['RAILS_ENV'] = environment
+      success = system('rspec spec/integration')
 
       raise "Integration specs failed in #{environment}" unless success
     end
 
-    task "test" do
-      puts "Running rake in dummy app"
-      ENV["RAILS_ENV"] = "test"
-      run_in_dummy_app "rake"
+    task 'test' do
+      puts 'Running rake in dummy app'
+      ENV['RAILS_ENV'] = 'test'
+      run_in_dummy_app 'rake'
     end
   end
 end
 
-namespace "db" do
-  desc "Set up databases for integration testing"
-  task "setup" do
-    puts "Setting up databases"
-    run_in_dummy_app "rm -f db/*.sqlite3"
-    run_in_dummy_app "RAILS_ENV=development rake db:schema:load db:seed"
-    run_in_dummy_app "RAILS_ENV=production rake db:schema:load db:seed"
-    run_in_dummy_app "RAILS_ENV=test rake db:environment:set db:schema:load"
+namespace 'db' do
+  desc 'Set up databases for integration testing'
+  task 'setup' do
+    puts 'Setting up databases'
+    run_in_dummy_app 'rm -f db/*.sqlite3'
+    run_in_dummy_app 'RAILS_ENV=development rake db:schema:load db:seed'
+    run_in_dummy_app 'RAILS_ENV=production rake db:schema:load db:seed'
+    run_in_dummy_app 'RAILS_ENV=test rake db:environment:set db:schema:load'
   end
 end

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -1,19 +1,19 @@
-require File.join(__dir__, "lib", "draper", "version")
+require File.join(__dir__, 'lib', 'draper', 'version')
 
 Gem::Specification.new do |s|
-  s.name        = "draper"
+  s.name        = 'draper'
   s.version     = Draper::VERSION
-  s.authors     = ["Jeff Casimir", "Steve Klabnik"]
-  s.email       = ["jeff@casimircreative.com", "steve@steveklabnik.com"]
-  s.homepage    = "http://github.com/drapergem/draper"
-  s.summary     = "View Models for Rails"
-  s.description = "Draper adds an object-oriented layer of presentation logic to your Rails apps."
-  s.license     = "MIT"
+  s.authors     = ['Jeff Casimir', 'Steve Klabnik']
+  s.email       = ['jeff@casimircreative.com', 'steve@steveklabnik.com']
+  s.homepage    = 'http://github.com/drapergem/draper'
+  s.summary     = 'View Models for Rails'
+  s.description = 'Draper adds an object-oriented layer of presentation logic to your Rails apps.'
+  s.license     = 'MIT'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.2.2'
 

--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -45,7 +45,7 @@ module Draper
     delegate :find, to: :decorated_collection
 
     def to_s
-      "#<#{self.class.name} of #{decorator_class || "inferred decorators"} for #{object.inspect}>"
+      "#<#{self.class.name} of #{decorator_class || 'inferred decorators'} for #{object.inspect}>"
     end
 
     def context=(value)

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -240,7 +240,7 @@ module Draper
 
     def self.object_class_name
       raise NameError if name.nil? || name.demodulize !~ /.+Decorator$/
-      name.chomp("Decorator")
+      name.chomp('Decorator')
     end
 
     def self.inferred_object_class

--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -4,6 +4,6 @@ require 'rails/test_unit/railtie'
 namespace :test do
   Rake::TestTask.new(decorators: 'test:prepare') do |t|
     t.libs << 'test'
-    t.pattern = "test/decorators/**/*_test.rb"
+    t.pattern = 'test/decorators/**/*_test.rb'
   end
 end

--- a/lib/draper/tasks/test.rake
+++ b/lib/draper/tasks/test.rake
@@ -2,8 +2,8 @@ require 'rake/testtask'
 require 'rails/test_unit/railtie'
 
 namespace :test do
-  Rake::TestTask.new(decorators: "test:prepare") do |t|
-    t.libs << "test"
+  Rake::TestTask.new(decorators: 'test:prepare') do |t|
+    t.libs << 'test'
     t.pattern = "test/decorators/**/*_test.rb"
   end
 end

--- a/lib/generators/controller_override.rb
+++ b/lib/generators/controller_override.rb
@@ -1,6 +1,6 @@
-require "rails/generators"
-require "rails/generators/rails/controller/controller_generator"
-require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
+require 'rails/generators'
+require 'rails/generators/rails/controller/controller_generator'
+require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
 
 module Rails
   module Generators

--- a/lib/generators/mini_test/decorator_generator.rb
+++ b/lib/generators/mini_test/decorator_generator.rb
@@ -7,7 +7,7 @@ module MiniTest
         File.expand_path('../templates', __FILE__)
       end
 
-      class_option :spec, type: :boolean, default: false, desc: "Use MiniTest::Spec DSL"
+      class_option :spec, type: :boolean, default: false, desc: 'Use MiniTest::Spec DSL'
 
       check_class_collision suffix: 'DecoratorTest'
 

--- a/lib/generators/mini_test/decorator_generator.rb
+++ b/lib/generators/mini_test/decorator_generator.rb
@@ -9,11 +9,11 @@ module MiniTest
 
       class_option :spec, type: :boolean, default: false, desc: "Use MiniTest::Spec DSL"
 
-      check_class_collision suffix: "DecoratorTest"
+      check_class_collision suffix: 'DecoratorTest'
 
       def create_test_file
-        template_type = options[:spec] ? "spec" : "test"
-        template "decorator_#{template_type}.rb", File.join("test/decorators", class_path, "#{singular_name}_decorator_test.rb")
+        template_type = options[:spec] ? 'spec' : 'test'
+        template "decorator_#{template_type}.rb", File.join('test/decorators', class_path, "#{singular_name}_decorator_test.rb")
       end
     end
   end

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -1,10 +1,10 @@
 module Rails
   module Generators
     class DecoratorGenerator < NamedBase
-      source_root File.expand_path("../templates", __FILE__)
-      check_class_collision suffix: "Decorator"
+      source_root File.expand_path('../templates', __FILE__)
+      check_class_collision suffix: 'Decorator'
 
-      class_option :parent, type: :string, desc: "The parent class for the generated decorator"
+      class_option :parent, type: :string, desc: 'The parent class for the generated decorator'
 
       def create_decorator_file
         template 'decorator.rb', File.join('app/decorators', class_path, "#{file_name}_decorator.rb")
@@ -15,12 +15,12 @@ module Rails
       private
 
       def parent_class_name
-        options.fetch("parent") do
+        options.fetch('parent') do
           begin
             require 'application_decorator'
             ApplicationDecorator
           rescue LoadError
-            "Draper::Decorator"
+            'Draper::Decorator'
           end
         end
       end

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -3,32 +3,32 @@ require 'support/shared_examples/view_helpers'
 
 module Draper
   describe CollectionDecorator do
-    it_behaves_like "view helpers", CollectionDecorator.new([])
+    it_behaves_like 'view helpers', CollectionDecorator.new([])
 
-    describe "#initialize" do
-      describe "options validation" do
+    describe '#initialize' do
+      describe 'options validation' do
 
-        it "does not raise error on valid options" do
+        it 'does not raise error on valid options' do
           valid_options = {with: Decorator, context: {}}
           expect{CollectionDecorator.new([], valid_options)}.not_to raise_error
         end
 
-        it "raises error on invalid options" do
-          expect{CollectionDecorator.new([], foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+        it 'raises error on invalid options' do
+          expect{CollectionDecorator.new([], foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
         end
       end
     end
 
-    context "with context" do
-      it "stores the context itself" do
-        context = {some: "context"}
+    context 'with context' do
+      it 'stores the context itself' do
+        context = {some: 'context'}
         decorator = CollectionDecorator.new([], context: context)
 
         expect(decorator.context).to be context
       end
 
-      it "passes context to the individual decorators" do
-        context = {some: "context"}
+      it 'passes context to the individual decorators' do
+        context = {some: 'context'}
         decorator = CollectionDecorator.new([Product.new, Product.new], context: context)
 
         decorator.each do |item|
@@ -37,20 +37,20 @@ module Draper
       end
     end
 
-    describe "#context=" do
-      it "updates the stored context" do
-        decorator = CollectionDecorator.new([], context: {some: "context"})
-        new_context = {other: "context"}
+    describe '#context=' do
+      it 'updates the stored context' do
+        decorator = CollectionDecorator.new([], context: {some: 'context'})
+        new_context = {other: 'context'}
 
         decorator.context = new_context
         expect(decorator.context).to be new_context
       end
 
-      context "when the collection is already decorated" do
+      context 'when the collection is already decorated' do
         it "updates the items' context" do
-          decorator = CollectionDecorator.new([Product.new, Product.new], context: {some: "context"})
+          decorator = CollectionDecorator.new([Product.new, Product.new], context: {some: 'context'})
           decorator.decorated_collection # trigger decoration
-          new_context = {other: "context"}
+          new_context = {other: 'context'}
 
           decorator.context = new_context
           decorator.each do |item|
@@ -59,17 +59,17 @@ module Draper
         end
       end
 
-      context "when the collection has not yet been decorated" do
-        it "does not trigger decoration" do
+      context 'when the collection has not yet been decorated' do
+        it 'does not trigger decoration' do
           decorator = CollectionDecorator.new([])
 
           expect(decorator).not_to receive(:decorated_collection)
-          decorator.context = {other: "context"}
+          decorator.context = {other: 'context'}
         end
 
-        it "sets context after decoration is triggered" do
-          decorator = CollectionDecorator.new([Product.new, Product.new], context: {some: "context"})
-          new_context = {other: "context"}
+        it 'sets context after decoration is triggered' do
+          decorator = CollectionDecorator.new([Product.new, Product.new], context: {some: 'context'})
+          new_context = {other: 'context'}
 
           decorator.context = new_context
           decorator.each do |item|
@@ -79,7 +79,7 @@ module Draper
       end
     end
 
-    describe "item decoration" do
+    describe 'item decoration' do
       it "sets decorated items' source models" do
         collection = [Product.new, Product.new]
         decorator = CollectionDecorator.new(collection)
@@ -89,16 +89,16 @@ module Draper
         end
       end
 
-      context "when the :with option was given" do
-        it "uses the :with option" do
+      context 'when the :with option was given' do
+        it 'uses the :with option' do
           decorator = CollectionDecorator.new([Product.new], with: OtherDecorator).first
 
           expect(decorator).to be_decorated_with OtherDecorator
         end
       end
 
-      context "when the :with option was not given" do
-        it "infers the item decorator from each item" do
+      context 'when the :with option was not given' do
+        it 'infers the item decorator from each item' do
           decorator = CollectionDecorator.new([double(decorate: :inferred_decorator)]).first
 
           expect(decorator).to be :inferred_decorator
@@ -106,22 +106,22 @@ module Draper
       end
     end
 
-    describe ".delegate" do
+    describe '.delegate' do
       protect_class ProductsDecorator
 
-      it "defaults the :to option to :object" do
+      it 'defaults the :to option to :object' do
         expect(Object).to receive(:delegate).with(:foo, :bar, to: :object)
         ProductsDecorator.delegate :foo, :bar
       end
 
-      it "does not overwrite the :to option if supplied" do
+      it 'does not overwrite the :to option if supplied' do
         expect(Object).to receive(:delegate).with(:foo, :bar, to: :baz)
         ProductsDecorator.delegate :foo, :bar, to: :baz
       end
     end
 
-    describe "#find" do
-      it "decorates Enumerable#find" do
+    describe '#find' do
+      it 'decorates Enumerable#find' do
         decorator = CollectionDecorator.new([])
 
         expect(decorator.decorated_collection).to receive(:find).and_return(:delegated)
@@ -129,9 +129,9 @@ module Draper
       end
     end
 
-    describe "#to_ary" do
+    describe '#to_ary' do
       # required for `render @collection` in Rails
-      it "delegates to the decorated collection" do
+      it 'delegates to the decorated collection' do
         decorator = CollectionDecorator.new([])
 
         expect(decorator.decorated_collection).to receive(:to_ary).and_return(:delegated)
@@ -139,16 +139,16 @@ module Draper
       end
     end
 
-    it "delegates array methods to the decorated collection" do
+    it 'delegates array methods to the decorated collection' do
       decorator = CollectionDecorator.new([])
 
       allow(decorator).to receive_message_chain(:decorated_collection, :[]).with(42).and_return(:delegated)
       expect(decorator[42]).to be :delegated
     end
 
-    describe "#==" do
-      context "when comparing to a collection decorator with the same object" do
-        it "returns true" do
+    describe '#==' do
+      context 'when comparing to a collection decorator with the same object' do
+        it 'returns true' do
           object = [Product.new, Product.new]
           decorator = CollectionDecorator.new(object)
           other = ProductsDecorator.new(object)
@@ -157,8 +157,8 @@ module Draper
         end
       end
 
-      context "when comparing to a collection decorator with a different object" do
-        it "returns false" do
+      context 'when comparing to a collection decorator with a different object' do
+        it 'returns false' do
           decorator = CollectionDecorator.new([Product.new, Product.new])
           other = ProductsDecorator.new([Product.new, Product.new])
 
@@ -166,8 +166,8 @@ module Draper
         end
       end
 
-      context "when comparing to a collection of the same items" do
-        it "returns true" do
+      context 'when comparing to a collection of the same items' do
+        it 'returns true' do
           object = [Product.new, Product.new]
           decorator = CollectionDecorator.new(object)
           other = object.dup
@@ -176,8 +176,8 @@ module Draper
         end
       end
 
-      context "when comparing to a collection of different items" do
-        it "returns false" do
+      context 'when comparing to a collection of different items' do
+        it 'returns false' do
           decorator = CollectionDecorator.new([Product.new, Product.new])
           other = [Product.new, Product.new]
 
@@ -185,8 +185,8 @@ module Draper
         end
       end
 
-      context "when the decorated collection has been modified" do
-        it "is no longer equal to the object" do
+      context 'when the decorated collection has been modified' do
+        it 'is no longer equal to the object' do
           object = [Product.new, Product.new]
           decorator = CollectionDecorator.new(object)
           other = object.dup
@@ -197,25 +197,25 @@ module Draper
       end
     end
 
-    describe "#to_s" do
-      context "when :with option was given" do
-        it "returns a string representation of the collection decorator" do
-          decorator = CollectionDecorator.new(["a", "b", "c"], with: ProductDecorator)
+    describe '#to_s' do
+      context 'when :with option was given' do
+        it 'returns a string representation of the collection decorator' do
+          decorator = CollectionDecorator.new(['a', 'b', 'c'], with: ProductDecorator)
 
           expect(decorator.to_s).to eq '#<Draper::CollectionDecorator of ProductDecorator for ["a", "b", "c"]>'
         end
       end
 
-      context "when :with option was not given" do
-        it "returns a string representation of the collection decorator" do
-          decorator = CollectionDecorator.new(["a", "b", "c"])
+      context 'when :with option was not given' do
+        it 'returns a string representation of the collection decorator' do
+          decorator = CollectionDecorator.new(['a', 'b', 'c'])
 
           expect(decorator.to_s).to eq '#<Draper::CollectionDecorator of inferred decorators for ["a", "b", "c"]>'
         end
       end
 
-      context "for a custom subclass" do
-        it "uses the custom class name" do
+      context 'for a custom subclass' do
+        it 'uses the custom class name' do
           decorator = ProductsDecorator.new([])
 
           expect(decorator.to_s).to match /ProductsDecorator/
@@ -252,8 +252,8 @@ module Draper
     describe '#kind_of?' do
       it 'asks the kind of its decorated collection' do
         decorator = ProductsDecorator.new([])
-        expect(decorator.decorated_collection).to receive(:kind_of?).with(Array).and_return("true")
-        expect(decorator.kind_of?(Array)).to eq "true"
+        expect(decorator.decorated_collection).to receive(:kind_of?).with(Array).and_return('true')
+        expect(decorator.kind_of?(Array)).to eq 'true'
       end
 
       context 'when asking the underlying collection returns false' do
@@ -272,8 +272,8 @@ module Draper
       end
     end
 
-    describe "#replace" do
-      it "replaces the decorated collection" do
+    describe '#replace' do
+      it 'replaces the decorated collection' do
         decorator = CollectionDecorator.new([Product.new])
         replacement = [:foo, :bar]
 
@@ -281,7 +281,7 @@ module Draper
         expect(decorator).to match_array replacement
       end
 
-      it "returns itself" do
+      it 'returns itself' do
         decorator = CollectionDecorator.new([Product.new])
 
         expect(decorator.replace([:foo, :bar])).to be decorator

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -125,7 +125,7 @@ module Draper
         decorator = CollectionDecorator.new([])
 
         expect(decorator.decorated_collection).to receive(:find).and_return(:delegated)
-        expect(decorator.find{|p| p.title == "title"}).to be :delegated
+        expect(decorator.find{|p| p.title == 'title'}).to be :delegated
       end
     end
 
@@ -241,7 +241,7 @@ module Draper
     end
 
     describe '#decorated_with?' do
-      it "checks if a decorator has been applied to a collection" do
+      it 'checks if a decorator has been applied to a collection' do
         decorator = ProductsDecorator.new([Product.new])
 
         expect(decorator).to be_decorated_with ProductsDecorator

--- a/spec/draper/decoratable/equality_spec.rb
+++ b/spec/draper/decoratable/equality_spec.rb
@@ -3,8 +3,8 @@ require 'support/shared_examples/decoratable_equality'
 
 module Draper
   describe Decoratable::Equality do
-    describe "#==" do
-      it_behaves_like "decoration-aware #==", Object.new.extend(Decoratable::Equality)
+    describe '#==' do
+      it_behaves_like 'decoration-aware #==', Object.new.extend(Decoratable::Equality)
     end
   end
 end

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -4,8 +4,8 @@ require 'support/shared_examples/decoratable_equality'
 module Draper
   describe Decoratable do
 
-    describe "#decorate" do
-      it "returns a decorator for self" do
+    describe '#decorate' do
+      it 'returns a decorator for self' do
         product = Product.new
         decorator = product.decorate
 
@@ -13,14 +13,14 @@ module Draper
         expect(decorator.object).to be product
      end
 
-      it "accepts context" do
-        context = {some: "context"}
+      it 'accepts context' do
+        context = {some: 'context'}
         decorator = Product.new.decorate(context: context)
 
         expect(decorator.context).to be context
       end
 
-      it "uses the #decorator_class" do
+      it 'uses the #decorator_class' do
         product = Product.new
         allow(product).to receive_messages decorator_class: OtherDecorator
 
@@ -28,46 +28,46 @@ module Draper
       end
     end
 
-    describe "#applied_decorators" do
-      it "returns an empty list" do
+    describe '#applied_decorators' do
+      it 'returns an empty list' do
         expect(Product.new.applied_decorators).to eq []
       end
     end
 
-    describe "#decorated_with?" do
-      it "returns false" do
+    describe '#decorated_with?' do
+      it 'returns false' do
         expect(Product.new).not_to be_decorated_with Decorator
       end
     end
 
-    describe "#decorated?" do
-      it "returns false" do
+    describe '#decorated?' do
+      it 'returns false' do
         expect(Product.new).not_to be_decorated
       end
     end
 
-    describe "#decorator_class?" do
-      it "returns true for decoratable model" do
+    describe '#decorator_class?' do
+      it 'returns true for decoratable model' do
         expect(Product.new.decorator_class?).to be_truthy
       end
 
-      it "returns false for non-decoratable model" do
+      it 'returns false for non-decoratable model' do
         expect(Model.new.decorator_class?).to be_falsey
       end
     end
 
-    describe ".decorator_class?" do
-      it "returns true for decoratable model" do
+    describe '.decorator_class?' do
+      it 'returns true for decoratable model' do
         expect(Product.decorator_class?).to be_truthy
       end
 
-      it "returns false for non-decoratable model" do
+      it 'returns false for non-decoratable model' do
         expect(Model.decorator_class?).to be_falsey
       end
     end
 
-    describe "#decorator_class" do
-      it "delegates to .decorator_class" do
+    describe '#decorator_class' do
+      it 'delegates to .decorator_class' do
         product = Product.new
 
         expect(Product).to receive(:decorator_class).and_return(:some_decorator)
@@ -75,19 +75,19 @@ module Draper
       end
     end
 
-    describe "#==" do
-      it_behaves_like "decoration-aware #==", Product.new
+    describe '#==' do
+      it_behaves_like 'decoration-aware #==', Product.new
     end
 
-    describe "#===" do
-      it "is true when #== is true" do
+    describe '#===' do
+      it 'is true when #== is true' do
         product = Product.new
 
         expect(product).to receive(:==).and_return(true)
         expect(product === :anything).to be_truthy
       end
 
-      it "is false when #== is false" do
+      it 'is false when #== is false' do
         product = Product.new
 
         expect(product).to receive(:==).and_return(false)
@@ -95,46 +95,46 @@ module Draper
       end
     end
 
-    describe ".====" do
-      it "is true for an instance" do
+    describe '.====' do
+      it 'is true for an instance' do
         expect(Product === Product.new).to be_truthy
       end
 
-      it "is true for a derived instance" do
+      it 'is true for a derived instance' do
         expect(Product === Class.new(Product).new).to be_truthy
       end
 
-      it "is false for an unrelated instance" do
+      it 'is false for an unrelated instance' do
         expect(Product === Model.new).to be_falsey
       end
 
-      it "is true for a decorated instance" do
+      it 'is true for a decorated instance' do
         decorator = Product.new.decorate
 
         expect(Product === decorator).to be_truthy
       end
 
-      it "is true for a decorated derived instance" do
+      it 'is true for a decorated derived instance' do
         decorator = Class.new(Product).new.decorate
 
         expect(Product === decorator).to be_truthy
       end
 
-      it "is false for a decorated unrelated instance" do
+      it 'is false for a decorated unrelated instance' do
         decorator = Other.new.decorate
 
         expect(Product === decorator).to be_falsey
       end
 
-      it "is false for a non-decorator which happens to respond to object" do
+      it 'is false for a non-decorator which happens to respond to object' do
         decorator = double(object: Product.new)
 
         expect(Product === decorator).to be_falsey
       end
     end
 
-    describe ".decorate" do
-      it "calls #decorate_collection on .decorator_class" do
+    describe '.decorate' do
+      it 'calls #decorate_collection on .decorator_class' do
         scoped = [Product.new]
         allow(Product).to receive(:all).and_return(scoped)
 
@@ -142,8 +142,8 @@ module Draper
         expect(Product.decorate).to be :decorated_collection
       end
 
-      it "accepts options" do
-        options = {with: ProductDecorator, context: {some: "context"}}
+      it 'accepts options' do
+        options = {with: ProductDecorator, context: {some: 'context'}}
         allow(Product).to receive(:all).and_return([])
 
         expect(Product.decorator_class).to receive(:decorate_collection).with([], options)
@@ -151,45 +151,45 @@ module Draper
       end
     end
 
-    describe ".decorator_class" do
-      context "for classes" do
-        it "infers the decorator from the class" do
+    describe '.decorator_class' do
+      context 'for classes' do
+        it 'infers the decorator from the class' do
           expect(Product.decorator_class).to be ProductDecorator
         end
 
-        context "without a decorator on its own" do
-          it "infers the decorator from a superclass" do
+        context 'without a decorator on its own' do
+          it 'infers the decorator from a superclass' do
             expect(SpecialProduct.decorator_class).to be ProductDecorator
           end
         end
       end
 
-      context "for ActiveModel classes" do
-        it "infers the decorator from the model name" do
-          allow(Product).to receive(:model_name){"Other"}
+      context 'for ActiveModel classes' do
+        it 'infers the decorator from the model name' do
+          allow(Product).to receive(:model_name){'Other'}
 
           expect(Product.decorator_class).to be OtherDecorator
         end
       end
 
-      context "in a namespace" do
-        context "for classes" do
-          it "infers the decorator from the class" do
+      context 'in a namespace' do
+        context 'for classes' do
+          it 'infers the decorator from the class' do
             expect(Namespaced::Product.decorator_class).to be Namespaced::ProductDecorator
           end
         end
 
-        context "for ActiveModel classes" do
-          it "infers the decorator from the model name" do
-            allow(Namespaced::Product).to receive(:model_name).and_return("Namespaced::Other")
+        context 'for ActiveModel classes' do
+          it 'infers the decorator from the model name' do
+            allow(Namespaced::Product).to receive(:model_name).and_return('Namespaced::Other')
 
             expect(Namespaced::Product.decorator_class).to be Namespaced::OtherDecorator
           end
         end
       end
 
-      context "when the decorator contains name error" do
-        it "throws an NameError" do
+      context 'when the decorator contains name error' do
+        it 'throws an NameError' do
           # We imitate ActiveSupport::Autoload behavior here in order to cause lazy NameError exception raising
           allow_any_instance_of(Module).to receive(:const_missing) { Class.new { any_nonexisting_method_name } }
 
@@ -198,13 +198,13 @@ module Draper
       end
 
       context "when the decorator can't be inferred" do
-        it "throws an UninferrableDecoratorError" do
+        it 'throws an UninferrableDecoratorError' do
           expect{Model.decorator_class}.to raise_error UninferrableDecoratorError
         end
       end
 
-      context "when an unrelated NameError is thrown" do
-        it "re-raises that error" do
+      context 'when an unrelated NameError is thrown' do
+        it 're-raises that error' do
           allow_any_instance_of(String).to receive(:constantize) { Draper::Base }
           expect{Product.decorator_class}.to raise_error NameError, /Draper::Base/
         end

--- a/spec/draper/decorated_association_spec.rb
+++ b/spec/draper/decorated_association_spec.rb
@@ -3,32 +3,32 @@ require 'spec_helper'
 module Draper
   describe DecoratedAssociation do
 
-    describe "#initialize" do
-      it "accepts valid options" do
+    describe '#initialize' do
+      it 'accepts valid options' do
         valid_options = {with: Decorator, scope: :foo, context: {}}
         expect{DecoratedAssociation.new(Decorator.new(Model.new), :association, valid_options)}.not_to raise_error
       end
 
-      it "rejects invalid options" do
-        expect{DecoratedAssociation.new(Decorator.new(Model.new), :association, foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+      it 'rejects invalid options' do
+        expect{DecoratedAssociation.new(Decorator.new(Model.new), :association, foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
       end
 
-      it "creates a factory" do
-        options = {with: Decorator, context: {foo: "bar"}}
+      it 'creates a factory' do
+        options = {with: Decorator, context: {foo: 'bar'}}
 
         expect(Factory).to receive(:new).with(options)
         DecoratedAssociation.new(double, :association, options)
       end
 
-      describe ":with option" do
-        it "defaults to nil" do
+      describe ':with option' do
+        it 'defaults to nil' do
           expect(Factory).to receive(:new).with(with: nil, context: anything())
           DecoratedAssociation.new(double, :association, {})
         end
       end
 
-      describe ":context option" do
-        it "defaults to the identity function" do
+      describe ':context option' do
+        it 'defaults to the identity function' do
           expect(Factory).to receive(:new) do |options|
             options[:context].call(:anything) == :anything
           end
@@ -37,12 +37,12 @@ module Draper
       end
     end
 
-    describe "#call" do
-      it "calls the factory" do
+    describe '#call' do
+      it 'calls the factory' do
         factory = double
         allow(Factory).to receive_messages(new: factory)
         associated = double
-        owner_context = {foo: "bar"}
+        owner_context = {foo: 'bar'}
         object = double(association: associated)
         owner = double(object: object, context: owner_context)
         decorated_association = DecoratedAssociation.new(owner, :association, {})
@@ -52,7 +52,7 @@ module Draper
         expect(decorated_association.call).to be decorated
       end
 
-      it "memoizes" do
+      it 'memoizes' do
         factory = double
         allow(Factory).to receive_messages(new: factory)
         owner = double(object: double(association: double), context: {})
@@ -64,8 +64,8 @@ module Draper
         expect(decorated_association.call).to be decorated
       end
 
-      context "when the :scope option was given" do
-        it "applies the scope before decoration" do
+      context 'when the :scope option was given' do
+        it 'applies the scope before decoration' do
           factory = double
           allow(Factory).to receive_messages(new: factory)
           scoped = double

--- a/spec/draper/decorates_assigned_spec.rb
+++ b/spec/draper/decorates_assigned_spec.rb
@@ -16,8 +16,8 @@ module Draper
       end
     end
 
-    describe ".decorates_assigned" do
-      it "adds helper methods" do
+    describe '.decorates_assigned' do
+      it 'adds helper methods' do
         controller_class.decorates_assigned :article, :author
 
         expect(controller_class.instance_methods).to include :article
@@ -27,33 +27,33 @@ module Draper
         expect(controller_class.helper_methods).to include :author
       end
 
-      it "creates a factory" do
+      it 'creates a factory' do
         allow(Factory).to receive(:new).once
         controller_class.decorates_assigned :article, :author
       end
 
-      it "passes options to the factory" do
-        options = {foo: "bar"}
+      it 'passes options to the factory' do
+        options = {foo: 'bar'}
 
         allow(Factory).to receive(:new).with(options)
         controller_class.decorates_assigned :article, :author, options
       end
 
-      describe "the generated method" do
-        it "decorates the instance variable" do
+      describe 'the generated method' do
+        it 'decorates the instance variable' do
           object = double
           factory = double
           allow(Factory).to receive_messages(new: factory)
 
           controller_class.decorates_assigned :article
           controller = controller_class.new
-          controller.instance_variable_set "@article", object
+          controller.instance_variable_set '@article', object
 
           expect(factory).to receive(:decorate).with(object, context_args: controller).and_return(:decorated)
           expect(controller.article).to be :decorated
         end
 
-        it "memoizes" do
+        it 'memoizes' do
           factory = double
           allow(Factory).to receive_messages(new: factory)
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -91,7 +91,7 @@ module Draper
     end
 
     describe '#context=' do
-      it "modifies the context" do
+      it 'modifies the context' do
         decorator = Decorator.new(Model.new, context: {some: 'context'})
         new_context = {other: 'context'}
 
@@ -427,7 +427,7 @@ module Draper
     end
 
     describe '#to_s' do
-      it "delegates to the object" do
+      it 'delegates to the object' do
         decorator = Decorator.new(double(to_s: :delegated))
 
         expect(decorator.to_s).to be :delegated
@@ -704,7 +704,7 @@ module Draper
         end
 
         context 'with include_private' do
-          it "returns true for its own private methods" do
+          it 'returns true for its own private methods' do
             Decorator.class_eval{private; def hello_world; end}
             decorator = Decorator.new(Model.new)
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -3,36 +3,36 @@ require 'support/shared_examples/view_helpers'
 
 module Draper
   describe Decorator do
-    it_behaves_like "view helpers", Decorator.new(Model.new)
+    it_behaves_like 'view helpers', Decorator.new(Model.new)
 
-    describe "#initialize" do
-      describe "options validation" do
-        it "does not raise error on valid options" do
+    describe '#initialize' do
+      describe 'options validation' do
+        it 'does not raise error on valid options' do
           valid_options = {context: {}}
           expect{Decorator.new(Model.new, valid_options)}.not_to raise_error
         end
 
-        it "raises error on invalid options" do
-          expect{Decorator.new(Model.new, foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+        it 'raises error on invalid options' do
+          expect{Decorator.new(Model.new, foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
         end
       end
 
-      it "sets the object" do
+      it 'sets the object' do
         object = Model.new
         decorator = Decorator.new(object)
 
         expect(decorator.object).to be object
       end
 
-      it "stores context" do
-        context = {some: "context"}
+      it 'stores context' do
+        context = {some: 'context'}
         decorator = Decorator.new(Model.new, context: context)
 
         expect(decorator.context).to be context
       end
 
-      context "when decorating an instance of itself" do
-        it "applies to the object instead" do
+      context 'when decorating an instance of itself' do
+        it 'applies to the object instead' do
           object = Model.new
           decorated = Decorator.new(object)
           redecorated = Decorator.new(decorated)
@@ -40,19 +40,19 @@ module Draper
           expect(redecorated.object).to be object
         end
 
-        context "with context" do
-          it "overwrites existing context" do
-            decorated = Decorator.new(Model.new, context: {some: "context"})
-            new_context = {other: "context"}
+        context 'with context' do
+          it 'overwrites existing context' do
+            decorated = Decorator.new(Model.new, context: {some: 'context'})
+            new_context = {other: 'context'}
             redecorated = Decorator.new(decorated, context: new_context)
 
             expect(redecorated.context).to be new_context
           end
         end
 
-        context "without context" do
-          it "preserves existing context" do
-            old_context = {some: "context"}
+        context 'without context' do
+          it 'preserves existing context' do
+            old_context = {some: 'context'}
             decorated = Decorator.new(Model.new, context: old_context)
             redecorated = Decorator.new(decorated)
 
@@ -61,26 +61,26 @@ module Draper
         end
       end
 
-      it "decorates other decorators" do
+      it 'decorates other decorators' do
         decorated = OtherDecorator.new(Model.new)
         redecorated = Decorator.new(decorated)
 
         expect(redecorated.object).to be decorated
       end
 
-      context "when it has been applied previously" do
-        it "warns" do
+      context 'when it has been applied previously' do
+        it 'warns' do
           decorated = OtherDecorator.new(Decorator.new(Model.new))
 
           warning_message = nil
           allow_any_instance_of(Object).to receive(:warn) { |instance, message| warning_message = message }
 
           expect{Decorator.new(decorated)}.to change{warning_message}
-          expect(warning_message).to start_with "Reapplying Draper::Decorator"
+          expect(warning_message).to start_with 'Reapplying Draper::Decorator'
           expect(warning_message).to include caller(1).first
         end
 
-        it "decorates anyway" do
+        it 'decorates anyway' do
           decorated = OtherDecorator.new(Decorator.new(Model.new))
           allow_any_instance_of(Object).to receive(:warn)
           redecorated = Decorator.decorate(decorated)
@@ -90,56 +90,56 @@ module Draper
       end
     end
 
-    describe "#context=" do
+    describe '#context=' do
       it "modifies the context" do
-        decorator = Decorator.new(Model.new, context: {some: "context"})
-        new_context = {other: "context"}
+        decorator = Decorator.new(Model.new, context: {some: 'context'})
+        new_context = {other: 'context'}
 
         decorator.context = new_context
         expect(decorator.context).to be new_context
       end
     end
 
-    describe ".decorate_collection" do
-      describe "options validation" do
+    describe '.decorate_collection' do
+      describe 'options validation' do
         before { allow(CollectionDecorator).to receive(:new) }
 
-        it "does not raise error on valid options" do
+        it 'does not raise error on valid options' do
           valid_options = {with: OtherDecorator, context: {}}
           expect{Decorator.decorate_collection([], valid_options)}.not_to raise_error
         end
 
-        it "raises error on invalid options" do
-          expect{Decorator.decorate_collection([], foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+        it 'raises error on invalid options' do
+          expect{Decorator.decorate_collection([], foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
         end
       end
 
-      context "without a custom collection decorator" do
-        it "creates a CollectionDecorator using itself for each item" do
+      context 'without a custom collection decorator' do
+        it 'creates a CollectionDecorator using itself for each item' do
           object = [Model.new]
 
           expect(CollectionDecorator).to receive(:new).with(object, with: Decorator)
           Decorator.decorate_collection(object)
         end
 
-        it "passes options to the collection decorator" do
-          options = {with: OtherDecorator, context: {some: "context"}}
+        it 'passes options to the collection decorator' do
+          options = {with: OtherDecorator, context: {some: 'context'}}
 
           expect(CollectionDecorator).to receive(:new).with([], options)
           Decorator.decorate_collection([], options)
         end
       end
 
-      context "with a custom collection decorator" do
-        it "creates a custom collection decorator using itself for each item" do
+      context 'with a custom collection decorator' do
+        it 'creates a custom collection decorator using itself for each item' do
           object = [Model.new]
 
           expect(ProductsDecorator).to receive(:new).with(object, with: ProductDecorator)
           ProductDecorator.decorate_collection(object)
         end
 
-        it "passes options to the collection decorator" do
-          options = {with: OtherDecorator, context: {some: "context"}}
+        it 'passes options to the collection decorator' do
+          options = {with: OtherDecorator, context: {some: 'context'}}
 
           expect(ProductsDecorator).to receive(:new).with([], options)
           ProductDecorator.decorate_collection([], options)
@@ -147,47 +147,47 @@ module Draper
       end
     end
 
-    describe ".decorates" do
+    describe '.decorates' do
       protect_class Decorator
 
-      it "sets .object_class with a symbol" do
+      it 'sets .object_class with a symbol' do
         Decorator.decorates :product
 
         expect(Decorator.object_class).to be Product
       end
 
-      it "sets .object_class with a string" do
-        Decorator.decorates "product"
+      it 'sets .object_class with a string' do
+        Decorator.decorates 'product'
 
         expect(Decorator.object_class).to be Product
       end
 
-      it "sets .object_class with a class" do
+      it 'sets .object_class with a class' do
         Decorator.decorates Product
 
         expect(Decorator.object_class).to be Product
       end
     end
 
-    describe ".object_class" do
+    describe '.object_class' do
       protect_class ProductDecorator
       protect_class Namespaced::ProductDecorator
 
-      context "when not set by .decorates" do
+      context 'when not set by .decorates' do
         it "raises an UninferrableObjectError for a so-named 'Decorator'" do
           expect{Decorator.object_class}.to raise_error UninferrableObjectError
         end
 
-        it "raises an UninferrableObjectError for anonymous decorators" do
+        it 'raises an UninferrableObjectError for anonymous decorators' do
           expect{Class.new(Decorator).object_class}.to raise_error UninferrableObjectError
         end
 
-        it "raises an UninferrableObjectError for a decorator without a model" do
+        it 'raises an UninferrableObjectError for a decorator without a model' do
           SomeDecorator = Class.new(Draper::Decorator)
           expect{SomeDecorator.object_class}.to raise_error UninferrableObjectError
         end
 
-        it "raises an UninferrableObjectError for other naming conventions" do
+        it 'raises an UninferrableObjectError for other naming conventions' do
           ProductPresenter = Class.new(Draper::Decorator)
           expect{ProductPresenter.object_class}.to raise_error UninferrableObjectError
         end
@@ -196,12 +196,12 @@ module Draper
           expect(ProductDecorator.object_class).to be Product
         end
 
-        it "infers the object class for namespaced decorators" do
+        it 'infers the object class for namespaced decorators' do
           expect(Namespaced::ProductDecorator.object_class).to be Namespaced::Product
         end
 
-        context "when an unrelated NameError is thrown" do
-          it "re-raises that error" do
+        context 'when an unrelated NameError is thrown' do
+          it 're-raises that error' do
             allow_any_instance_of(String).to receive(:constantize) { SomethingThatDoesntExist }
             expect{ProductDecorator.object_class}.to raise_error NameError, /SomethingThatDoesntExist/
           end
@@ -209,14 +209,14 @@ module Draper
       end
     end
 
-    describe ".object_class?" do
-      it "returns truthy when .object_class is set" do
+    describe '.object_class?' do
+      it 'returns truthy when .object_class is set' do
         allow(Decorator).to receive(:object_class).and_return(Model)
 
         expect(Decorator.object_class?).to be_truthy
       end
 
-      it "returns false when .object_class is not inferrable" do
+      it 'returns false when .object_class is not inferrable' do
         allow(Decorator).to receive(:object_class).and_raise(UninferrableObjectError.new(Decorator))
 
         expect(Decorator.object_class?).to be_falsey
@@ -238,24 +238,24 @@ module Draper
       end
     end
 
-    describe ".decorates_association" do
+    describe '.decorates_association' do
       protect_class Decorator
 
-      describe "options validation" do
+      describe 'options validation' do
         before { allow(DecoratedAssociation).to receive(:new).and_return(->{}) }
 
-        it "does not raise error on valid options" do
+        it 'does not raise error on valid options' do
           valid_options = {with: Class, scope: :sorted, context: {}}
           expect{Decorator.decorates_association(:children, valid_options)}.not_to raise_error
         end
 
-        it "raises error on invalid options" do
-          expect{Decorator.decorates_association(:children, foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+        it 'raises error on invalid options' do
+          expect{Decorator.decorates_association(:children, foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
         end
       end
 
-      describe "defines an association method" do
-        it "creates a DecoratedAssociation" do
+      describe 'defines an association method' do
+        it 'creates a DecoratedAssociation' do
           options = {with: Class.new, scope: :foo, context: {}}
           Decorator.decorates_association :children, options
           decorator = Decorator.new(Model.new)
@@ -264,7 +264,7 @@ module Draper
           decorator.children
         end
 
-        it "memoizes the DecoratedAssociation" do
+        it 'memoizes the DecoratedAssociation' do
           Decorator.decorates_association :children
           decorator = Decorator.new(Model.new)
 
@@ -273,7 +273,7 @@ module Draper
           decorator.children
         end
 
-        it "calls the DecoratedAssociation" do
+        it 'calls the DecoratedAssociation' do
           Decorator.decorates_association :children
           decorator = Decorator.new(Model.new)
           decorated_association = ->{}
@@ -285,16 +285,16 @@ module Draper
       end
     end
 
-    describe ".decorates_associations" do
+    describe '.decorates_associations' do
       protect_class Decorator
 
-      it "decorates each of the associations" do
+      it 'decorates each of the associations' do
         expect(Decorator).to receive(:decorates_association).with(:friends, {})
         expect(Decorator).to receive(:decorates_association).with(:enemies, {})
         Decorator.decorates_associations :friends, :enemies
       end
 
-      it "dispatches options" do
+      it 'dispatches options' do
         options = {with: Class.new, scope: :foo, context: {}}
 
         expect(Decorator).to receive(:decorates_association).with(:friends, options)
@@ -303,16 +303,16 @@ module Draper
       end
     end
 
-    describe "#applied_decorators" do
-      it "returns a list of decorators applied to a model" do
+    describe '#applied_decorators' do
+      it 'returns a list of decorators applied to a model' do
         decorator = ProductDecorator.new(OtherDecorator.new(Decorator.new(Model.new)))
 
         expect(decorator.applied_decorators).to eq [Decorator, OtherDecorator, ProductDecorator]
       end
     end
 
-    describe "#decorated_with?" do
-      it "checks if a decorator has been applied to a model" do
+    describe '#decorated_with?' do
+      it 'checks if a decorator has been applied to a model' do
         decorator = ProductDecorator.new(Decorator.new(Model.new))
 
         expect(decorator).to be_decorated_with Decorator
@@ -321,16 +321,16 @@ module Draper
       end
     end
 
-    describe "#decorated?" do
-      it "returns true" do
+    describe '#decorated?' do
+      it 'returns true' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator).to be_decorated
       end
     end
 
-    describe "#object" do
-      it "returns the wrapped object" do
+    describe '#object' do
+      it 'returns the wrapped object' do
         object = Model.new
         decorator = Decorator.new(object)
 
@@ -338,7 +338,7 @@ module Draper
         expect(decorator.model).to be object
       end
 
-      it "is aliased to #model" do
+      it 'is aliased to #model' do
         object = Model.new
         decorator = Decorator.new(object)
 
@@ -346,9 +346,9 @@ module Draper
       end
     end
 
-    describe "aliasing object to object class name" do
-      context "when object_class is inferrable from the decorator name" do
-        it "aliases object to the object class name" do
+    describe 'aliasing object to object class name' do
+      context 'when object_class is inferrable from the decorator name' do
+        it 'aliases object to the object class name' do
           object = double
           decorator = ProductDecorator.new(object)
 
@@ -356,8 +356,8 @@ module Draper
         end
       end
 
-      context "when object_class is set by decorates" do
-        it "aliases object to the object class name" do
+      context 'when object_class is set by decorates' do
+        it 'aliases object to the object class name' do
           decorator_class = Class.new(Decorator) { decorates Product }
           object = double
           decorator = decorator_class.new(object)
@@ -367,8 +367,8 @@ module Draper
       end
 
       context "when object_class's name is several words long" do
-        it "underscores the method name" do
-          stub_const "LongWindedModel", Class.new
+        it 'underscores the method name' do
+          stub_const 'LongWindedModel', Class.new
           decorator_class = Class.new(Decorator) { decorates LongWindedModel }
           object = double
           decorator = decorator_class.new(object)
@@ -377,8 +377,8 @@ module Draper
         end
       end
 
-      context "when object_class is not set" do
-        it "does not alias object" do
+      context 'when object_class is not set' do
+        it 'does not alias object' do
           decorator_class = Class.new(Decorator)
 
           expect(decorator_class.instance_methods).to eq Decorator.instance_methods
@@ -386,47 +386,47 @@ module Draper
       end
     end
 
-    describe "#to_model" do
-      it "returns the decorator" do
+    describe '#to_model' do
+      it 'returns the decorator' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator.to_model).to be decorator
       end
     end
 
-    describe "#to_param" do
-      it "delegates to the object" do
+    describe '#to_param' do
+      it 'delegates to the object' do
         decorator = Decorator.new(double(to_param: :delegated))
 
         expect(decorator.to_param).to be :delegated
       end
     end
 
-    describe "#present?" do
-      it "delegates to the object" do
+    describe '#present?' do
+      it 'delegates to the object' do
         decorator = Decorator.new(double(present?: :delegated))
 
         expect(decorator.present?).to be :delegated
       end
     end
 
-    describe "#blank?" do
-      it "delegates to the object" do
+    describe '#blank?' do
+      it 'delegates to the object' do
         decorator = Decorator.new(double(blank?: :delegated))
 
         expect(decorator.blank?).to be :delegated
       end
     end
 
-    describe "#to_partial_path" do
-      it "delegates to the object" do
+    describe '#to_partial_path' do
+      it 'delegates to the object' do
         decorator = Decorator.new(double(to_partial_path: :delegated))
 
         expect(decorator.to_partial_path).to be :delegated
       end
     end
 
-    describe "#to_s" do
+    describe '#to_s' do
       it "delegates to the object" do
         decorator = Decorator.new(double(to_s: :delegated))
 
@@ -434,66 +434,66 @@ module Draper
       end
     end
 
-    describe "#inspect" do
-      it "returns a detailed description of the decorator" do
+    describe '#inspect' do
+      it 'returns a detailed description of the decorator' do
         decorator = ProductDecorator.new(double)
 
         expect(decorator.inspect).to match /#<ProductDecorator:0x\h+ .+>/
       end
 
-      it "includes the object" do
-        decorator = Decorator.new(double(inspect: "#<the object>"))
+      it 'includes the object' do
+        decorator = Decorator.new(double(inspect: '#<the object>'))
 
-        expect(decorator.inspect).to include "@object=#<the object>"
+        expect(decorator.inspect).to include '@object=#<the object>'
       end
 
-      it "includes the context" do
-        decorator = Decorator.new(double, context: {foo: "bar"})
+      it 'includes the context' do
+        decorator = Decorator.new(double, context: {foo: 'bar'})
 
         expect(decorator.inspect).to include '@context={:foo=>"bar"}'
       end
 
-      it "includes other instance variables" do
+      it 'includes other instance variables' do
         decorator = Decorator.new(double)
-        decorator.instance_variable_set :@foo, "bar"
+        decorator.instance_variable_set :@foo, 'bar'
 
         expect(decorator.inspect).to include '@foo="bar"'
       end
     end
 
-    describe "#attributes" do
+    describe '#attributes' do
       it "returns only the object's attributes that are implemented by the decorator" do
-        decorator = Decorator.new(double(attributes: {foo: "bar", baz: "qux"}))
+        decorator = Decorator.new(double(attributes: {foo: 'bar', baz: 'qux'}))
         allow(decorator).to receive(:foo)
 
-        expect(decorator.attributes).to eq({foo: "bar"})
+        expect(decorator.attributes).to eq({foo: 'bar'})
       end
     end
 
-    describe ".model_name" do
-      it "delegates to the object class" do
+    describe '.model_name' do
+      it 'delegates to the object class' do
         allow(Decorator).to receive(:object_class).and_return(double(model_name: :delegated))
 
         expect(Decorator.model_name).to be :delegated
       end
     end
 
-    describe "#==" do
-      it "works for a object that does not include Decoratable" do
+    describe '#==' do
+      it 'works for a object that does not include Decoratable' do
         object = Object.new
         decorator = Decorator.new(object)
 
         expect(decorator).to eq Decorator.new(object)
       end
 
-      it "works for a multiply-decorated object that does not include Decoratable" do
+      it 'works for a multiply-decorated object that does not include Decoratable' do
         object = Object.new
         decorator = Decorator.new(object)
 
         expect(decorator).to eq ProductDecorator.new(Decorator.new(object))
       end
 
-      it "is true when object #== is true" do
+      it 'is true when object #== is true' do
         object = Model.new
         decorator = Decorator.new(object)
         other = double(object: Model.new)
@@ -502,7 +502,7 @@ module Draper
         expect(decorator == other).to be_truthy
       end
 
-      it "is false when object #== is false" do
+      it 'is false when object #== is false' do
         object = Model.new
         decorator = Decorator.new(object)
         other = double(object: Model.new)
@@ -512,15 +512,15 @@ module Draper
       end
     end
 
-    describe "#===" do
-      it "is true when #== is true" do
+    describe '#===' do
+      it 'is true when #== is true' do
         decorator = Decorator.new(Model.new)
         allow(decorator).to receive(:==) { true }
 
         expect(decorator === :anything).to be_truthy
       end
 
-      it "is false when #== is false" do
+      it 'is false when #== is false' do
         decorator = Decorator.new(Model.new)
         allow(decorator).to receive(:==).with(:anything).and_return(false)
 
@@ -528,15 +528,15 @@ module Draper
       end
     end
 
-    describe "#eql?" do
-      it "is true when #eql? is true" do
+    describe '#eql?' do
+      it 'is true when #eql? is true' do
         first = Decorator.new('foo')
         second = Decorator.new('foo')
 
         expect(first.eql? second).to be
       end
 
-      it "is false when #eql? is false" do
+      it 'is false when #eql? is false' do
         first = Decorator.new('foo')
         second = Decorator.new('bar')
 
@@ -544,8 +544,8 @@ module Draper
       end
     end
 
-    describe "#hash" do
-      it "is consistent for equal objects" do
+    describe '#hash' do
+      it 'is consistent for equal objects' do
         object = Model.new
         first = Decorator.new(object)
         second = Decorator.new(object)
@@ -554,27 +554,27 @@ module Draper
       end
     end
 
-    describe ".delegate" do
+    describe '.delegate' do
       protect_class Decorator
 
-      it "defaults the :to option to :object" do
+      it 'defaults the :to option to :object' do
         expect(Object).to receive(:delegate).with(:foo, :bar, to: :object)
         Decorator.delegate :foo, :bar
       end
 
-      it "does not overwrite the :to option if supplied" do
+      it 'does not overwrite the :to option if supplied' do
         expect(Object).to receive(:delegate).with(:foo, :bar, to: :baz)
         Decorator.delegate :foo, :bar, to: :baz
       end
     end
 
-    context "with .delegate_all" do
+    context 'with .delegate_all' do
       protect_class Decorator
 
       before { Decorator.delegate_all }
 
-      describe "#method_missing" do
-        it "delegates missing methods that exist on the object" do
+      describe '#method_missing' do
+        it 'delegates missing methods that exist on the object' do
           decorator = Decorator.new(double(hello_world: :delegated))
 
           expect(decorator.hello_world).to be :delegated
@@ -583,7 +583,7 @@ module Draper
         it 'delegates `super` to parent class first' do
           parent_decorator_class = Class.new(Decorator) do
             def hello_world
-              "parent#hello_world"
+              'parent#hello_world'
             end
           end
 
@@ -619,7 +619,7 @@ module Draper
           expect{decorator.hello_world}.to raise_error NoMethodError
         end
 
-        it "allows decorator to decorate different classes of objects" do
+        it 'allows decorator to decorate different classes of objects' do
           decorator_1 = Decorator.new(double)
           decorator_2 = Decorator.new(double(hello_world: :delegated))
 
@@ -627,7 +627,7 @@ module Draper
           expect(decorator_1.methods).not_to include :hello_world
         end
 
-        it "passes blocks to delegated methods" do
+        it 'passes blocks to delegated methods' do
           object = Model.new
           allow(object).to receive(:hello_world) { |*args, &block| block.call }
           decorator = Decorator.new(object)
@@ -635,13 +635,13 @@ module Draper
           expect(decorator.hello_world{:yielded}).to be :yielded
         end
 
-        it "does not confuse Kernel#Array" do
+        it 'does not confuse Kernel#Array' do
           decorator = Decorator.new(Model.new)
 
           expect(Array(decorator)).to be_an Array
         end
 
-        it "delegates already-delegated methods" do
+        it 'delegates already-delegated methods' do
           object = Class.new{ delegate :bar, to: :foo }.new
           allow(object).to receive_messages foo: double(bar: :delegated)
           decorator = Decorator.new(object)
@@ -649,14 +649,14 @@ module Draper
           expect(decorator.bar).to be :delegated
         end
 
-        it "does not delegate private methods" do
+        it 'does not delegate private methods' do
           object = Class.new{ private; def hello_world; end }.new
           decorator = Decorator.new(object)
 
           expect{decorator.hello_world}.to raise_error NoMethodError
         end
 
-        it "does not delegate methods that do not exist on the object" do
+        it 'does not delegate methods that do not exist on the object' do
           decorator = Decorator.new(Model.new)
 
           expect(decorator.methods).not_to include :hello_world
@@ -665,15 +665,15 @@ module Draper
         end
       end
 
-      context ".method_missing" do
-        context "without an object class" do
-          it "raises a NoMethodError on missing methods" do
+      context '.method_missing' do
+        context 'without an object class' do
+          it 'raises a NoMethodError on missing methods' do
             expect{Decorator.hello_world}.to raise_error NoMethodError
           end
         end
 
-        context "with an object class" do
-          it "delegates methods that exist on the object class" do
+        context 'with an object class' do
+          it 'delegates methods that exist on the object class' do
             object_class = Class.new
             allow(object_class).to receive_messages hello_world: :delegated
             allow(Decorator).to receive_messages object_class: object_class
@@ -681,7 +681,7 @@ module Draper
             expect(Decorator.hello_world).to be :delegated
           end
 
-          it "does not delegate methods that do not exist on the object class" do
+          it 'does not delegate methods that do not exist on the object class' do
             allow(Decorator).to receive_messages object_class: Class.new
 
             expect{Decorator.hello_world}.to raise_error NoMethodError
@@ -689,8 +689,8 @@ module Draper
         end
       end
 
-      describe "#respond_to?" do
-        it "returns true for its own methods" do
+      describe '#respond_to?' do
+        it 'returns true for its own methods' do
           Decorator.class_eval{def hello_world; end}
           decorator = Decorator.new(Model.new)
 
@@ -703,7 +703,7 @@ module Draper
           expect(decorator).to respond_to :hello_world
         end
 
-        context "with include_private" do
+        context 'with include_private' do
           it "returns true for its own private methods" do
             Decorator.class_eval{private; def hello_world; end}
             decorator = Decorator.new(Model.new)
@@ -720,21 +720,21 @@ module Draper
         end
       end
 
-      describe ".respond_to?" do
-        context "without a object class" do
-          it "returns true for its own class methods" do
+      describe '.respond_to?' do
+        context 'without a object class' do
+          it 'returns true for its own class methods' do
             Decorator.class_eval{def self.hello_world; end}
 
             expect(Decorator).to respond_to :hello_world
           end
 
-          it "returns false for other class methods" do
+          it 'returns false for other class methods' do
             expect(Decorator).not_to respond_to :goodnight_moon
           end
         end
 
-        context "with a object class" do
-          it "returns true for its own class methods" do
+        context 'with a object class' do
+          it 'returns true for its own class methods' do
             Decorator.class_eval{def self.hello_world; end}
             allow(Decorator).to receive_messages object_class: Class.new
 
@@ -749,8 +749,8 @@ module Draper
         end
       end
 
-      describe "#respond_to_missing?" do
-        it "allows #method to be called on delegated methods" do
+      describe '#respond_to_missing?' do
+        it 'allows #method to be called on delegated methods' do
           object = Class.new{def hello_world; end}.new
           decorator = Decorator.new(object)
 
@@ -758,8 +758,8 @@ module Draper
         end
       end
 
-      describe ".respond_to_missing?" do
-        it "allows .method to be called on delegated class methods" do
+      describe '.respond_to_missing?' do
+        it 'allows .method to be called on delegated class methods' do
           allow(Decorator).to receive_messages object_class: double(hello_world: :delegated)
 
           expect(Decorator.method(:hello_world)).not_to be_nil
@@ -767,67 +767,67 @@ module Draper
       end
     end
 
-    describe "class spoofing" do
-      it "pretends to be a kind of the object class" do
+    describe 'class spoofing' do
+      it 'pretends to be a kind of the object class' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator.kind_of?(Model)).to be_truthy
         expect(decorator.is_a?(Model)).to be_truthy
       end
 
-      it "is still a kind of its own class" do
+      it 'is still a kind of its own class' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator.kind_of?(Decorator)).to be_truthy
         expect(decorator.is_a?(Decorator)).to be_truthy
       end
 
-      it "pretends to be an instance of the object class" do
+      it 'pretends to be an instance of the object class' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator.instance_of?(Model)).to be_truthy
       end
 
-      it "is still an instance of its own class" do
+      it 'is still an instance of its own class' do
         decorator = Decorator.new(Model.new)
 
         expect(decorator.instance_of?(Decorator)).to be_truthy
       end
     end
 
-    describe ".decorates_finders" do
+    describe '.decorates_finders' do
       protect_class Decorator
 
-      it "extends the Finders module" do
+      it 'extends the Finders module' do
         expect(Decorator).not_to be_a_kind_of Finders
         Decorator.decorates_finders
         expect(Decorator).to be_a_kind_of Finders
       end
     end
 
-    describe "Enumerable hash and equality functionality" do
-      describe "#uniq" do
-        it "removes duplicate objects with same decorator" do
+    describe 'Enumerable hash and equality functionality' do
+      describe '#uniq' do
+        it 'removes duplicate objects with same decorator' do
           object = Model.new
           array = [Decorator.new(object), Decorator.new(object)]
 
           expect(array.uniq.count).to eq(1)
         end
 
-        it "separates different objects with identical decorators" do
+        it 'separates different objects with identical decorators' do
           array = [Decorator.new('foo'), Decorator.new('bar')]
 
           expect(array.uniq.count).to eq(2)
         end
 
-        it "separates identical objects with different decorators" do
+        it 'separates identical objects with different decorators' do
           object = Model.new
           array = [Decorator.new(object), OtherDecorator.new(object)]
 
           expect(array.uniq.count).to eq(2)
         end
 
-        it "distinguishes between an objects and its decorated version" do
+        it 'distinguishes between an objects and its decorated version' do
           object = Model.new
           array = [Decorator.new(object), object]
 

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -3,27 +3,27 @@ require 'spec_helper'
 module Draper
   describe Factory do
 
-    describe "#initialize" do
-      it "accepts valid options" do
-        valid_options = {with: Decorator, context: {foo: "bar"}}
+    describe '#initialize' do
+      it 'accepts valid options' do
+        valid_options = {with: Decorator, context: {foo: 'bar'}}
         expect{Factory.new(valid_options)}.not_to raise_error
       end
 
-      it "rejects invalid options" do
-        expect{Factory.new(foo: "bar")}.to raise_error ArgumentError, /Unknown key/
+      it 'rejects invalid options' do
+        expect{Factory.new(foo: 'bar')}.to raise_error ArgumentError, /Unknown key/
       end
     end
 
-    describe "#decorate" do
-      context "when object is nil" do
-        it "returns nil" do
+    describe '#decorate' do
+      context 'when object is nil' do
+        it 'returns nil' do
           factory = Factory.new
 
           expect(factory.decorate(nil)).to be_nil
         end
       end
 
-      it "calls a worker" do
+      it 'calls a worker' do
         factory = Factory.new
         worker = ->(*){ :decorated }
 
@@ -31,7 +31,7 @@ module Draper
         expect(factory.decorate(double)).to be :decorated
       end
 
-      it "passes the object to the worker" do
+      it 'passes the object to the worker' do
         factory = Factory.new
         object = double
 
@@ -39,8 +39,8 @@ module Draper
         factory.decorate(object)
       end
 
-      context "when the :with option was given" do
-        it "passes the decorator class to the worker" do
+      context 'when the :with option was given' do
+        it 'passes the decorator class to the worker' do
           decorator_class = double
           factory = Factory.new(with: decorator_class)
 
@@ -49,8 +49,8 @@ module Draper
         end
       end
 
-      context "when the :with option was omitted" do
-        it "passes nil to the worker" do
+      context 'when the :with option was omitted' do
+        it 'passes nil to the worker' do
           factory = Factory.new
 
           expect(Factory::Worker).to receive(:new).with(nil, anything()).and_return(->(*){})
@@ -58,33 +58,33 @@ module Draper
         end
       end
 
-      it "passes options to the call" do
+      it 'passes options to the call' do
         factory = Factory.new
         worker = ->(*){}
         allow(Factory::Worker).to receive(:new).and_return(worker)
-        options = {foo: "bar"}
+        options = {foo: 'bar'}
 
         allow(worker).to receive(:call).with(options)
         factory.decorate(double, options)
       end
 
-      context "when the :context option was given" do
-        it "sets the passed context" do
-          factory = Factory.new(context: {foo: "bar"})
+      context 'when the :context option was given' do
+        it 'sets the passed context' do
+          factory = Factory.new(context: {foo: 'bar'})
           worker = ->(*){}
           allow(Factory::Worker).to receive_messages new: worker
 
-          expect(worker).to receive(:call).with(baz: "qux", context: {foo: "bar"})
-          factory.decorate(double, {baz: "qux"})
+          expect(worker).to receive(:call).with(baz: 'qux', context: {foo: 'bar'})
+          factory.decorate(double, {baz: 'qux'})
         end
 
-        it "is overridden by explicitly-specified context" do
-          factory = Factory.new(context: {foo: "bar"})
+        it 'is overridden by explicitly-specified context' do
+          factory = Factory.new(context: {foo: 'bar'})
           worker = ->(*){}
           allow(Factory::Worker).to receive_messages new: worker
 
-          expect(worker).to receive(:call).with(context: {baz: "qux"})
-          factory.decorate(double, context: {baz: "qux"})
+          expect(worker).to receive(:call).with(context: {baz: 'qux'})
+          factory.decorate(double, context: {baz: 'qux'})
         end
       end
     end
@@ -93,10 +93,10 @@ module Draper
 
   describe Factory::Worker do
 
-    describe "#call" do
-      it "calls the decorator method" do
+    describe '#call' do
+      it 'calls the decorator method' do
         object = double
-        options = {foo: "bar"}
+        options = {foo: 'bar'}
         worker = Factory::Worker.new(double, object)
         decorator = ->(*){}
         allow(worker).to receive(:decorator){ decorator }
@@ -105,18 +105,18 @@ module Draper
         expect(worker.call(options)).to be :decorated
       end
 
-      context "when the :context option is callable" do
-        it "calls it" do
+      context 'when the :context option is callable' do
+        it 'calls it' do
           worker = Factory::Worker.new(double, double)
           decorator = ->(*){}
           allow(worker).to receive_messages decorator: decorator
-          context = {foo: "bar"}
+          context = {foo: 'bar'}
 
           expect(decorator).to receive(:call).with(anything(), context: context)
           worker.call(context: ->{ context })
         end
 
-        it "receives arguments from the :context_args option" do
+        it 'receives arguments from the :context_args option' do
           worker = Factory::Worker.new(double, double)
           allow(worker).to receive_messages decorator: ->(*){}
           context = ->{}
@@ -125,43 +125,43 @@ module Draper
           worker.call(context: context, context_args: [:foo, :bar])
         end
 
-        it "wraps non-arrays passed to :context_args" do
+        it 'wraps non-arrays passed to :context_args' do
           worker = Factory::Worker.new(double, double)
           allow(worker).to receive_messages decorator: ->(*){}
           context = ->{}
-          hash = {foo: "bar"}
+          hash = {foo: 'bar'}
 
           expect(context).to receive(:call).with(hash)
           worker.call(context: context, context_args: hash)
         end
       end
 
-      context "when the :context option is not callable" do
+      context 'when the :context option is not callable' do
         it "doesn't call it" do
           worker = Factory::Worker.new(double, double)
           decorator = ->(*){}
           allow(worker).to receive_messages decorator: decorator
-          context = {foo: "bar"}
+          context = {foo: 'bar'}
 
           expect(decorator).to receive(:call).with(anything(), context: context)
           worker.call(context: context)
         end
       end
 
-      it "does not pass the :context_args option to the decorator" do
+      it 'does not pass the :context_args option to the decorator' do
         worker = Factory::Worker.new(double, double)
         decorator = ->(*){}
         allow(worker).to receive_messages decorator: decorator
 
-        expect(decorator).to receive(:call).with(anything(), foo: "bar")
-        worker.call(foo: "bar", context_args: [])
+        expect(decorator).to receive(:call).with(anything(), foo: 'bar')
+        worker.call(foo: 'bar', context_args: [])
       end
     end
 
-    describe "#decorator" do
-      context "for a singular object" do
-        context "when decorator_class is specified" do
-          it "returns the .decorate method from the decorator" do
+    describe '#decorator' do
+      context 'for a singular object' do
+        context 'when decorator_class is specified' do
+          it 'returns the .decorate method from the decorator' do
             decorator_class = Class.new(Decorator)
             worker = Factory::Worker.new(decorator_class, double)
 
@@ -169,11 +169,11 @@ module Draper
           end
         end
 
-        context "when decorator_class is unspecified" do
-          context "and the object is decoratable" do
+        context 'when decorator_class is unspecified' do
+          context 'and the object is decoratable' do
             it "returns the object's #decorate method" do
               object = double
-              options = {foo: "bar"}
+              options = {foo: 'bar'}
               worker = Factory::Worker.new(nil, object)
 
               expect(object).to receive(:decorate).with(options).and_return(:decorated)
@@ -181,8 +181,8 @@ module Draper
             end
           end
 
-          context "and the object is not decoratable" do
-            it "raises an error" do
+          context 'and the object is not decoratable' do
+            it 'raises an error' do
               object = double
               worker = Factory::Worker.new(nil, object)
 
@@ -191,9 +191,9 @@ module Draper
           end
         end
 
-        context "when the object is a struct" do
-          it "returns a singular decorator" do
-            object = Struct.new(:stuff).new("things")
+        context 'when the object is a struct' do
+          it 'returns a singular decorator' do
+            object = Struct.new(:stuff).new('things')
 
             decorator_class = Class.new(Decorator)
             worker = Factory::Worker.new(decorator_class, object)
@@ -203,9 +203,9 @@ module Draper
         end
       end
 
-      context "for a collection object" do
-        context "when decorator_class is a CollectionDecorator" do
-          it "returns the .decorate method from the collection decorator" do
+      context 'for a collection object' do
+        context 'when decorator_class is a CollectionDecorator' do
+          it 'returns the .decorate method from the collection decorator' do
             decorator_class = Class.new(CollectionDecorator)
             worker = Factory::Worker.new(decorator_class, [])
 
@@ -213,8 +213,8 @@ module Draper
           end
         end
 
-        context "when decorator_class is a Decorator" do
-          it "returns the .decorate_collection method from the decorator" do
+        context 'when decorator_class is a Decorator' do
+          it 'returns the .decorate_collection method from the decorator' do
             decorator_class = Class.new(Decorator)
             worker = Factory::Worker.new(decorator_class, [])
 
@@ -222,8 +222,8 @@ module Draper
           end
         end
 
-        context "when decorator_class is unspecified" do
-          context "and the object is decoratable" do
+        context 'when decorator_class is unspecified' do
+          context 'and the object is decoratable' do
             it "returns the .decorate_collection method from the object's decorator" do
               object = []
               decorator_class = Class.new(Decorator)
@@ -231,13 +231,13 @@ module Draper
               allow(object).to receive(:decorate){ nil }
               worker = Factory::Worker.new(nil, object)
 
-              expect(decorator_class).to receive(:decorate_collection).with(object, foo: "bar", with: nil).and_return(:decorated)
-              expect(worker.decorator.call(object, foo: "bar")).to be :decorated
+              expect(decorator_class).to receive(:decorate_collection).with(object, foo: 'bar', with: nil).and_return(:decorated)
+              expect(worker.decorator.call(object, foo: 'bar')).to be :decorated
             end
           end
 
-          context "and the object is not decoratable" do
-            it "returns the .decorate method from CollectionDecorator" do
+          context 'and the object is not decoratable' do
+            it 'returns the .decorate method from CollectionDecorator' do
               worker = Factory::Worker.new(nil, [])
 
               expect(worker.decorator).to eq CollectionDecorator.method(:decorate)

--- a/spec/draper/finders_spec.rb
+++ b/spec/draper/finders_spec.rb
@@ -5,13 +5,13 @@ module Draper
     protect_class ProductDecorator
     before { ProductDecorator.decorates_finders }
 
-    describe ".find" do
-      it "proxies to the model class" do
+    describe '.find' do
+      it 'proxies to the model class' do
         expect(Product).to receive(:find).with(1)
         ProductDecorator.find(1)
       end
 
-      it "decorates the result" do
+      it 'decorates the result' do
         found = Product.new
         allow(Product).to receive(:find).and_return(found)
         decorator = ProductDecorator.find(1)
@@ -19,85 +19,85 @@ module Draper
         expect(decorator.object).to be found
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:find)
-        context = {some: "context"}
+        context = {some: 'context'}
         decorator = ProductDecorator.find(1, context: context)
 
         expect(decorator.context).to be context
       end
     end
 
-    describe ".find_by_(x)" do
-      it "proxies to the model class" do
-        expect(Product).to receive(:find_by_name).with("apples")
-        ProductDecorator.find_by_name("apples")
+    describe '.find_by_(x)' do
+      it 'proxies to the model class' do
+        expect(Product).to receive(:find_by_name).with('apples')
+        ProductDecorator.find_by_name('apples')
       end
 
-      it "decorates the result" do
+      it 'decorates the result' do
         found = Product.new
         allow(Product).to receive(:find_by_name).and_return(found)
-        decorator = ProductDecorator.find_by_name("apples")
+        decorator = ProductDecorator.find_by_name('apples')
         expect(decorator).to be_a ProductDecorator
         expect(decorator.object).to be found
       end
 
-      it "proxies complex ProductDecorators" do
-        expect(Product).to receive(:find_by_name_and_size).with("apples", "large")
-        ProductDecorator.find_by_name_and_size("apples", "large")
+      it 'proxies complex ProductDecorators' do
+        expect(Product).to receive(:find_by_name_and_size).with('apples', 'large')
+        ProductDecorator.find_by_name_and_size('apples', 'large')
       end
 
-      it "proxies find_last_by_(x) ProductDecorators" do
-        expect(Product).to receive(:find_last_by_name_and_size).with("apples", "large")
-        ProductDecorator.find_last_by_name_and_size("apples", "large")
+      it 'proxies find_last_by_(x) ProductDecorators' do
+        expect(Product).to receive(:find_last_by_name_and_size).with('apples', 'large')
+        ProductDecorator.find_last_by_name_and_size('apples', 'large')
       end
 
-      it "proxies find_or_initialize_by_(x) ProductDecorators" do
-        expect(Product).to receive(:find_or_initialize_by_name_and_size).with("apples", "large")
-        ProductDecorator.find_or_initialize_by_name_and_size("apples", "large")
+      it 'proxies find_or_initialize_by_(x) ProductDecorators' do
+        expect(Product).to receive(:find_or_initialize_by_name_and_size).with('apples', 'large')
+        ProductDecorator.find_or_initialize_by_name_and_size('apples', 'large')
       end
 
-      it "proxies find_or_create_by_(x) ProductDecorators" do
-        expect(Product).to receive(:find_or_create_by_name_and_size).with("apples", "large")
-        ProductDecorator.find_or_create_by_name_and_size("apples", "large")
+      it 'proxies find_or_create_by_(x) ProductDecorators' do
+        expect(Product).to receive(:find_or_create_by_name_and_size).with('apples', 'large')
+        ProductDecorator.find_or_create_by_name_and_size('apples', 'large')
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:find_by_name_and_size)
-        context = {some: "context"}
-        decorator = ProductDecorator.find_by_name_and_size("apples", "large", context: context)
+        context = {some: 'context'}
+        decorator = ProductDecorator.find_by_name_and_size('apples', 'large', context: context)
 
         expect(decorator.context).to be context
       end
     end
 
-    describe ".find_all_by_" do
-      it "proxies to the model class" do
-        expect(Product).to receive(:find_all_by_name_and_size).with("apples", "large").and_return([])
-        ProductDecorator.find_all_by_name_and_size("apples", "large")
+    describe '.find_all_by_' do
+      it 'proxies to the model class' do
+        expect(Product).to receive(:find_all_by_name_and_size).with('apples', 'large').and_return([])
+        ProductDecorator.find_all_by_name_and_size('apples', 'large')
       end
 
-      it "decorates the result" do
+      it 'decorates the result' do
         found = [Product.new, Product.new]
         allow(Product).to receive(:find_all_by_name).and_return(found)
-        decorator = ProductDecorator.find_all_by_name("apples")
+        decorator = ProductDecorator.find_all_by_name('apples')
 
         expect(decorator).to be_a Draper::CollectionDecorator
         expect(decorator.decorator_class).to be ProductDecorator
         expect(decorator).to eq found
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:find_all_by_name)
-        context = {some: "context"}
-        decorator = ProductDecorator.find_all_by_name("apples", context: context)
+        context = {some: 'context'}
+        decorator = ProductDecorator.find_all_by_name('apples', context: context)
 
         expect(decorator.context).to be context
       end
     end
 
-    describe ".all" do
-      it "returns a decorated collection" do
+    describe '.all' do
+      it 'returns a decorated collection' do
         found = [Product.new, Product.new]
         allow(Product).to receive_messages all: found
         decorator = ProductDecorator.all
@@ -107,22 +107,22 @@ module Draper
         expect(decorator).to eq found
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:all)
-        context = {some: "context"}
+        context = {some: 'context'}
         decorator = ProductDecorator.all(context: context)
 
         expect(decorator.context).to be context
       end
     end
 
-    describe ".first" do
-      it "proxies to the model class" do
+    describe '.first' do
+      it 'proxies to the model class' do
         expect(Product).to receive(:first)
         ProductDecorator.first
       end
 
-      it "decorates the result" do
+      it 'decorates the result' do
         first = Product.new
         allow(Product).to receive(:first).and_return(first)
         decorator = ProductDecorator.first
@@ -130,22 +130,22 @@ module Draper
         expect(decorator.object).to be first
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:first)
-        context = {some: "context"}
+        context = {some: 'context'}
         decorator = ProductDecorator.first(context: context)
 
         expect(decorator.context).to be context
       end
     end
 
-    describe ".last" do
-      it "proxies to the model class" do
+    describe '.last' do
+      it 'proxies to the model class' do
         expect(Product).to receive(:last)
         ProductDecorator.last
       end
 
-      it "decorates the result" do
+      it 'decorates the result' do
         last = Product.new
         allow(Product).to receive(:last).and_return(last)
         decorator = ProductDecorator.last
@@ -153,9 +153,9 @@ module Draper
         expect(decorator.object).to be last
       end
 
-      it "passes context to the decorator" do
+      it 'passes context to the decorator' do
         allow(Product).to receive(:last)
-        context = {some: "context"}
+        context = {some: 'context'}
         decorator = ProductDecorator.last(context: context)
 
         expect(decorator.context).to be context

--- a/spec/draper/helper_proxy_spec.rb
+++ b/spec/draper/helper_proxy_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 module Draper
   describe HelperProxy do
-    describe "#initialize" do
-      it "sets the view context" do
+    describe '#initialize' do
+      it 'sets the view context' do
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
@@ -11,10 +11,10 @@ module Draper
       end
     end
 
-    describe "#method_missing" do
+    describe '#method_missing' do
       protect_class HelperProxy
 
-      it "proxies methods to the view context" do
+      it 'proxies methods to the view context' do
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
@@ -22,7 +22,7 @@ module Draper
         expect(helper_proxy.foo(:passed)).to be :passed
       end
 
-      it "passes blocks" do
+      it 'passes blocks' do
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
@@ -30,8 +30,8 @@ module Draper
         expect(helper_proxy.foo{:yielded}).to be :yielded
       end
 
-      it "defines the method for better performance" do
-        helper_proxy = HelperProxy.new(double(foo: "bar"))
+      it 'defines the method for better performance' do
+        helper_proxy = HelperProxy.new(double(foo: 'bar'))
 
         expect(HelperProxy.instance_methods).not_to include :foo
         helper_proxy.foo
@@ -39,16 +39,16 @@ module Draper
       end
     end
 
-    describe "#respond_to_missing?" do
-      it "allows #method to be called on the view context" do
-        helper_proxy = HelperProxy.new(double(foo: "bar"))
+    describe '#respond_to_missing?' do
+      it 'allows #method to be called on the view context' do
+        helper_proxy = HelperProxy.new(double(foo: 'bar'))
 
         expect(helper_proxy.respond_to?(:foo)).to be_truthy
       end
     end
 
-    describe "proxying methods which are overriding" do
-      it "proxies :capture" do
+    describe 'proxying methods which are overriding' do
+      it 'proxies :capture' do
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 

--- a/spec/draper/lazy_helpers_spec.rb
+++ b/spec/draper/lazy_helpers_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 module Draper
   describe LazyHelpers do
-    describe "#method_missing" do
+    describe '#method_missing' do
       let(:decorator) do
         Struct.new(:helpers){include Draper::LazyHelpers}.new(double)
       end
 
-      it "proxies methods to #helpers" do
+      it 'proxies methods to #helpers' do
         allow(decorator.helpers).to receive(:foo) { |arg| arg }
         expect(decorator.foo(:passed)).to be :passed
       end
 
-      it "passes blocks" do
+      it 'passes blocks' do
         allow(decorator.helpers).to receive(:foo) { |&block| block.call }
         expect(decorator.foo{:yielded}).to be :yielded
       end

--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 def fake_view_context
-  double("ViewContext")
+  double('ViewContext')
 end
 
 def fake_controller(view_context = fake_view_context)
-  double("Controller", view_context: view_context, request: double("Request"))
+  double('Controller', view_context: view_context, request: double('Request'))
 end
 
 module Draper
   describe ViewContext::BuildStrategy::Full do
-    describe "#call" do
-      context "when a current controller is set" do
+    describe '#call' do
+      context 'when a current controller is set' do
         it "returns the controller's view context" do
           view_context = fake_view_context
           allow(ViewContext).to receive_messages controller: fake_controller(view_context)
@@ -21,8 +21,8 @@ module Draper
         end
       end
 
-      context "when a current controller is not set" do
-        it "uses ApplicationController" do
+      context 'when a current controller is not set' do
+        it 'uses ApplicationController' do
           expect(Draper::ViewContext.controller).to be_nil
           view_context = ViewContext::BuildStrategy::Full.new.call
           expect(view_context.controller).to eq Draper::ViewContext.controller
@@ -45,7 +45,7 @@ module Draper
         expect(controller.view_context.params).to be controller.params
       end
 
-      it "compatible with rails 5.1 change on ActionController::TestRequest.create method" do
+      it 'compatible with rails 5.1 change on ActionController::TestRequest.create method' do
         ActionController::TestRequest.class_eval do
           if ActionController::TestRequest.method(:create).parameters.first == []
             def create controller_class
@@ -62,7 +62,7 @@ module Draper
         expect(controller.request).to be_an ActionController::TestRequest
       end
 
-      it "adds methods to the view context from the constructor block" do
+      it 'adds methods to the view context from the constructor block' do
         allow(ViewContext).to receive(:controller).and_return(fake_controller)
         strategy = ViewContext::BuildStrategy::Full.new do
           def a_helper_method; end
@@ -71,7 +71,7 @@ module Draper
         expect(strategy.call).to respond_to :a_helper_method
       end
 
-      it "includes modules into the view context from the constructor block" do
+      it 'includes modules into the view context from the constructor block' do
         view_context = Object.new
         allow(ViewContext).to receive(:controller).and_return(fake_controller(view_context))
         helpers = Module.new do
@@ -87,8 +87,8 @@ module Draper
   end
 
   describe ViewContext::BuildStrategy::Fast do
-    describe "#call" do
-      it "returns an instance of a subclass of ActionView::Base" do
+    describe '#call' do
+      it 'returns an instance of a subclass of ActionView::Base' do
         strategy = ViewContext::BuildStrategy::Fast.new
 
         returned = strategy.call
@@ -97,19 +97,19 @@ module Draper
         expect(returned.class).not_to be ActionView::Base
       end
 
-      it "returns different instances each time" do
+      it 'returns different instances each time' do
         strategy = ViewContext::BuildStrategy::Fast.new
 
         expect(strategy.call).not_to be strategy.call
       end
 
-      it "returns the same subclass each time" do
+      it 'returns the same subclass each time' do
         strategy = ViewContext::BuildStrategy::Fast.new
 
         expect(strategy.call.class).to be strategy.call.class
       end
 
-      it "adds methods to the view context from the constructor block" do
+      it 'adds methods to the view context from the constructor block' do
         strategy = ViewContext::BuildStrategy::Fast.new do
           def a_helper_method; end
         end
@@ -117,7 +117,7 @@ module Draper
         expect(strategy.call).to respond_to :a_helper_method
       end
 
-      it "includes modules into the view context from the constructor block" do
+      it 'includes modules into the view context from the constructor block' do
         helpers = Module.new do
           def a_helper_method; end
         end

--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -30,7 +30,7 @@ module Draper
         end
       end
 
-      it "adds a request if one is not defined" do
+      it 'adds a request if one is not defined' do
         controller = Class.new(ActionController::Base).new
         allow(ViewContext).to receive_messages controller: controller
         strategy = ViewContext::BuildStrategy::Full.new

--- a/spec/draper/view_context_spec.rb
+++ b/spec/draper/view_context_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Draper
   describe ViewContext do
-    describe "#view_context" do
+    describe '#view_context' do
       let(:base) { Class.new { def view_context; :controller_view_context; end } }
       let(:controller) { Class.new(base) { include ViewContext } }
 
@@ -16,16 +16,16 @@ module Draper
       end
     end
 
-    describe ".controller" do
-      it "returns the stored controller from RequestStore" do
+    describe '.controller' do
+      it 'returns the stored controller from RequestStore' do
         allow(RequestStore).to receive_messages store: {current_controller: :stored_controller}
 
         expect(ViewContext.controller).to be :stored_controller
       end
     end
 
-    describe ".controller=" do
-      it "stores a controller in RequestStore" do
+    describe '.controller=' do
+      it 'stores a controller in RequestStore' do
         store = {}
         allow(RequestStore).to receive_messages store: store
 
@@ -33,7 +33,7 @@ module Draper
         expect(store[:current_controller]).to be :stored_controller
       end
 
-      it "cleans context when controller changes" do
+      it 'cleans context when controller changes' do
         store = {
           current_controller: :stored_controller,
           current_view_context: :stored_view_context
@@ -62,15 +62,15 @@ module Draper
       end
     end
 
-    describe ".current" do
-      it "returns the stored view context from RequestStore" do
+    describe '.current' do
+      it 'returns the stored view context from RequestStore' do
         allow(RequestStore).to receive_messages store: {current_view_context: :stored_view_context}
 
         expect(ViewContext.current).to be :stored_view_context
       end
 
-      context "when no view context is stored" do
-        it "builds a view context" do
+      context 'when no view context is stored' do
+        it 'builds a view context' do
           allow(RequestStore).to receive_messages store: {}
           allow(ViewContext).to receive_messages build_strategy: ->{ :new_view_context }
           allow(HelperProxy).to receive(:new).with(:new_view_context).and_return(:new_helper_proxy)
@@ -78,7 +78,7 @@ module Draper
           expect(ViewContext.current).to be :new_helper_proxy
         end
 
-        it "stores the built view context" do
+        it 'stores the built view context' do
           store = {}
           allow(RequestStore).to receive_messages store: store
           allow(ViewContext).to receive_messages build_strategy: ->{ :new_view_context }
@@ -90,8 +90,8 @@ module Draper
       end
     end
 
-    describe ".current=" do
-      it "stores a helper proxy for the view context in RequestStore" do
+    describe '.current=' do
+      it 'stores a helper proxy for the view context in RequestStore' do
         store = {}
         allow(RequestStore).to receive_messages store: store
         allow(HelperProxy).to receive(:new).with(:stored_view_context).and_return(:stored_helper_proxy)
@@ -101,8 +101,8 @@ module Draper
       end
     end
 
-    describe ".clear!" do
-      it "clears the stored controller and view controller" do
+    describe '.clear!' do
+      it 'clears the stored controller and view controller' do
         store = {current_controller: :stored_controller, current_view_context: :stored_view_context}
         allow(RequestStore).to receive_messages store: store
 
@@ -112,23 +112,23 @@ module Draper
       end
     end
 
-    describe ".build" do
-      it "returns a new view context using the build strategy" do
+    describe '.build' do
+      it 'returns a new view context using the build strategy' do
         allow(ViewContext).to receive_messages build_strategy: ->{ :new_view_context }
 
         expect(ViewContext.build).to be :new_view_context
       end
     end
 
-    describe ".build!" do
-      it "returns a helper proxy for the new view context" do
+    describe '.build!' do
+      it 'returns a helper proxy for the new view context' do
         allow(ViewContext).to receive_messages build_strategy: ->{ :new_view_context }
         allow(HelperProxy).to receive(:new).with(:new_view_context).and_return(:new_helper_proxy)
 
         expect(ViewContext.build!).to be :new_helper_proxy
       end
 
-      it "stores the helper proxy" do
+      it 'stores the helper proxy' do
         store = {}
         allow(RequestStore).to receive_messages store: store
         allow(ViewContext).to receive_messages build_strategy: ->{ :new_view_context }
@@ -139,39 +139,39 @@ module Draper
       end
     end
 
-    describe ".build_strategy" do
-      it "defaults to full" do
+    describe '.build_strategy' do
+      it 'defaults to full' do
         expect(ViewContext.build_strategy).to be_a ViewContext::BuildStrategy::Full
       end
 
-      it "memoizes" do
+      it 'memoizes' do
         expect(ViewContext.build_strategy).to be ViewContext.build_strategy
       end
     end
 
-    describe ".test_strategy" do
+    describe '.test_strategy' do
       protect_module ViewContext
 
-      context "with :fast" do
-        it "creates a fast strategy" do
+      context 'with :fast' do
+        it 'creates a fast strategy' do
           ViewContext.test_strategy :fast
           expect(ViewContext.build_strategy).to be_a ViewContext::BuildStrategy::Fast
         end
 
-        it "passes a block to the strategy" do
+        it 'passes a block to the strategy' do
           allow(ViewContext::BuildStrategy::Fast).to receive(:new) { |&block| block.call }
 
           expect(ViewContext.test_strategy(:fast){:passed}).to be :passed
         end
       end
 
-      context "with :full" do
-        it "creates a full strategy" do
+      context 'with :full' do
+        it 'creates a full strategy' do
           ViewContext.test_strategy :full
           expect(ViewContext.build_strategy).to be_a ViewContext::BuildStrategy::Full
         end
 
-        it "passes a block to the strategy" do
+        it 'passes a block to the strategy' do
           allow(ViewContext::BuildStrategy::Full).to receive(:new) { |&block| block.call }
 
           expect(ViewContext.test_strategy(:full){:passed}).to be :passed

--- a/spec/draper/view_helpers_spec.rb
+++ b/spec/draper/view_helpers_spec.rb
@@ -3,6 +3,6 @@ require 'support/shared_examples/view_helpers'
 
 module Draper
   describe ViewHelpers do
-    it_behaves_like "view helpers", Class.new{include ViewHelpers}.new
+    it_behaves_like 'view helpers', Class.new{include ViewHelpers}.new
   end
 end

--- a/spec/dummy/app/controllers/localized_urls.rb
+++ b/spec/dummy/app/controllers/localized_urls.rb
@@ -1,5 +1,5 @@
 module LocalizedUrls
   def default_url_options(options = {})
-    {locale: I18n.locale, host: "www.example.com", port: 12345}
+    {locale: I18n.locale, host: 'www.example.com', port: 12345}
   end
 end

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -14,7 +14,7 @@ class PostsController < BaseController
   private
 
   def goodnight_moon
-    "Goodnight, moon!"
+    'Goodnight, moon!'
   end
   helper_method :goodnight_moon
 end

--- a/spec/dummy/app/decorators/post_decorator.rb
+++ b/spec/dummy/app/decorators/post_decorator.rb
@@ -8,9 +8,9 @@ class PostDecorator < Draper::Decorator
 
   def posted_date
     if created_at.to_date == DateTime.now.utc.to_date
-      "Today"
+      'Today'
     else
-      "Not Today"
+      'Not Today'
     end
   end
 
@@ -35,11 +35,11 @@ class PostDecorator < Draper::Decorator
   end
 
   def truncated
-    h.truncate("Once upon a time in a world far far away", length: 17, separator: ' ')
+    h.truncate('Once upon a time in a world far far away', length: 17, separator: ' ')
   end
 
   def html_escaped
-    h.html_escape("<script>danger</script>")
+    h.html_escape('<script>danger</script>')
   end
 
   def hello_world

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def hello_world
-    "Hello, world!"
+    'Hello, world!'
   end
 end

--- a/spec/dummy/app/mailers/post_mailer.rb
+++ b/spec/dummy/app/mailers/post_mailer.rb
@@ -1,19 +1,19 @@
 class PostMailer < ApplicationMailer
-  default from: "from@example.com"
-  layout "application"
+  default from: 'from@example.com'
+  layout 'application'
 
   # Mailers don't import app/helpers automatically
   helper :application
 
   def decorated_email(post)
     @post = post.decorate
-    mail to: "to@example.com", subject: "A decorated post"
+    mail to: 'to@example.com', subject: 'A decorated post'
   end
 
   private
 
   def goodnight_moon
-    "Goodnight, moon!"
+    'Goodnight, moon!'
   end
   helper_method :goodnight_moon
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,7 +1,7 @@
 Dummy::Application.routes.draw do
-  scope "(:locale)", locale: /en|zh/ do
+  scope '(:locale)', locale: /en|zh/ do
     resources :posts, only: [:show] do
-      get "mail", on: :member
+      get 'mail', on: :member
     end
   end
 

--- a/spec/dummy/fast_spec/post_decorator_spec.rb
+++ b/spec/dummy/fast_spec/post_decorator_spec.rb
@@ -11,11 +11,11 @@ describe PostDecorator do
   let(:decorator) { PostDecorator.new(object) }
   let(:object) { Post.new(42) }
 
-  it "can use built-in helpers" do
-    expect(decorator.truncated).to eq "Once upon a..."
+  it 'can use built-in helpers' do
+    expect(decorator.truncated).to eq 'Once upon a...'
   end
 
-  it "can use built-in private helpers" do
+  it 'can use built-in private helpers' do
     expect(decorator.html_escaped).to eq "&lt;script&gt;danger&lt;/script&gt;"
   end
 

--- a/spec/dummy/lib/tasks/test.rake
+++ b/spec/dummy/lib/tasks/test.rake
@@ -3,14 +3,14 @@ require 'rspec/core/rake_task'
 
 Rake::Task[:test].clear
 Rake::TestTask.new :test do |t|
-  t.libs << "test"
-  t.pattern = "test/**/*_test.rb"
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
 end
 
 RSpec::Core::RakeTask.new :spec
 
 RSpec::Core::RakeTask.new :fast_spec do |t|
-  t.pattern = "fast_spec/**/*_spec.rb"
+  t.pattern = 'fast_spec/**/*_spec.rb'
 end
 
 task default: [:test, :spec, :fast_spec]

--- a/spec/dummy/spec/decorators/active_model_serializers_spec.rb
+++ b/spec/dummy/spec/decorators/active_model_serializers_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Draper::CollectionDecorator do
-  describe "#active_model_serializer" do
-    it "returns ActiveModel::Serializer::CollectionSerializer" do
+  describe '#active_model_serializer' do
+    it 'returns ActiveModel::Serializer::CollectionSerializer' do
       collection_decorator  = Draper::CollectionDecorator.new([])
       collection_serializer = ActiveModel::Serializer.serializer_for(collection_decorator)
 

--- a/spec/dummy/spec/decorators/devise_spec.rb
+++ b/spec/dummy/spec/decorators/devise_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
 if defined?(Devise)
-  describe "A decorator spec" do
-    it "can sign in a real user" do
+  describe 'A decorator spec' do
+    it 'can sign in a real user' do
       user = User.new
       sign_in user
 
       expect(helper.current_user).to be user
     end
 
-    it "can sign in a mock user" do
-      user = double("User")
+    it 'can sign in a mock user' do
+      user = double('User')
       sign_in :user, user
 
       expect(helper.current_user).to be user
     end
 
-    it "can sign in a real admin" do
+    it 'can sign in a real admin' do
       admin = Admin.new
       sign_in admin
 
       expect(helper.current_admin).to be admin
     end
 
-    it "can sign in a mock admin" do
-      admin = double("Admin")
+    it 'can sign in a mock admin' do
+      admin = double('Admin')
       sign_in :admin, admin
 
       expect(helper.current_admin).to be admin
     end
 
-    it "can sign out a real user" do
+    it 'can sign out a real user' do
       user = User.new
       sign_in user
       sign_out user
@@ -38,15 +38,15 @@ if defined?(Devise)
       expect(helper.current_user).to be_nil
     end
 
-    it "can sign out a mock user" do
-      user = double("User")
+    it 'can sign out a mock user' do
+      user = double('User')
       sign_in :user, user
       sign_out :user
 
       expect(helper.current_user).to be_nil
     end
 
-    it "can sign out without a user" do
+    it 'can sign out without a user' do
       sign_out :user
 
       expect(helper.current_user).to be_nil

--- a/spec/dummy/spec/decorators/helpers_spec.rb
+++ b/spec/dummy/spec/decorators/helpers_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
-describe "A decorator spec" do
-  it "can access helpers through `helper`" do
-    expect(helper.content_tag(:p, "Help!")).to eq "<p>Help!</p>"
+describe 'A decorator spec' do
+  it 'can access helpers through `helper`' do
+    expect(helper.content_tag(:p, 'Help!')).to eq '<p>Help!</p>'
   end
 
-  it "can access helpers through `helpers`" do
-    expect(helpers.content_tag(:p, "Help!")).to eq "<p>Help!</p>"
+  it 'can access helpers through `helpers`' do
+    expect(helpers.content_tag(:p, 'Help!')).to eq '<p>Help!</p>'
   end
 
-  it "can access helpers through `h`" do
-    expect(h.content_tag(:p, "Help!")).to eq "<p>Help!</p>"
+  it 'can access helpers through `h`' do
+    expect(h.content_tag(:p, 'Help!')).to eq '<p>Help!</p>'
   end
 
-  it "gets the same helper object as a decorator" do
+  it 'gets the same helper object as a decorator' do
     decorator = Draper::Decorator.new(Object.new)
 
     expect(helpers).to be decorator.helpers

--- a/spec/dummy/spec/decorators/post_decorator_spec.rb
+++ b/spec/dummy/spec/decorators/post_decorator_spec.rb
@@ -4,39 +4,39 @@ describe PostDecorator do
   let(:decorator) { PostDecorator.new(object) }
   let(:object) { Post.create }
 
-  it "can use built-in helpers" do
-    expect(decorator.truncated).to eq "Once upon a..."
+  it 'can use built-in helpers' do
+    expect(decorator.truncated).to eq 'Once upon a...'
   end
 
-  it "can use built-in private helpers" do
+  it 'can use built-in private helpers' do
     expect(decorator.html_escaped).to eq "&lt;script&gt;danger&lt;/script&gt;"
   end
 
-  it "can use user-defined helpers from app/helpers" do
-    expect(decorator.hello_world).to eq "Hello, world!"
+  it 'can use user-defined helpers from app/helpers' do
+    expect(decorator.hello_world).to eq 'Hello, world!'
   end
 
-  it "can be passed to path helpers" do
+  it 'can be passed to path helpers' do
     expect(helpers.post_path(decorator)).to eq "/en/posts/#{object.id}"
   end
 
-  it "can use path helpers with its model" do
+  it 'can use path helpers with its model' do
     expect(decorator.path_with_model).to eq "/en/posts/#{object.id}"
   end
 
-  it "can use path helpers with its id" do
+  it 'can use path helpers with its id' do
     expect(decorator.path_with_id).to eq "/en/posts/#{object.id}"
   end
 
-  it "can be passed to url helpers" do
+  it 'can be passed to url helpers' do
     expect(helpers.post_url(decorator)).to eq "http://www.example.com:12345/en/posts/#{object.id}"
   end
 
-  it "can use url helpers with its model" do
+  it 'can use url helpers with its model' do
     expect(decorator.url_with_model).to eq "http://www.example.com:12345/en/posts/#{object.id}"
   end
 
-  it "can use url helpers with its id" do
+  it 'can use url helpers with its id' do
     expect(decorator.url_with_id).to eq "http://www.example.com:12345/en/posts/#{object.id}"
   end
 
@@ -44,21 +44,21 @@ describe PostDecorator do
     expect(decorator.link).to eq "<a href=\"/en/posts/#{object.id}\">#{object.id}</a>"
   end
 
-  it "serializes overriden attributes" do
-    expect(decorator.serializable_hash["updated_at"]).to be :overridden
+  it 'serializes overriden attributes' do
+    expect(decorator.serializable_hash['updated_at']).to be :overridden
   end
 
-  it "serializes to JSON" do
+  it 'serializes to JSON' do
     json = decorator.to_json
     expect(json).to match /"updated_at":"overridden"/
   end
 
-  it "serializes to XML" do
+  it 'serializes to XML' do
     xml = Capybara.string(decorator.to_xml)
-    expect(xml).to have_css "post > updated-at", text: "overridden"
+    expect(xml).to have_css 'post > updated-at', text: 'overridden'
   end
 
-  it "uses a test view context from BaseController" do
+  it 'uses a test view context from BaseController' do
     expect(Draper::ViewContext.current.controller).to be_an BaseController
   end
 end

--- a/spec/dummy/spec/decorators/spec_type_spec.rb
+++ b/spec/dummy/spec/decorators/spec_type_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe "A spec in this folder" do
-  it "is a decorator spec" do
+describe 'A spec in this folder' do
+  it 'is a decorator spec' do
     expect(RSpec.current_example.metadata[:type]).to be :decorator
   end
 end

--- a/spec/dummy/spec/decorators/view_context_spec.rb
+++ b/spec/dummy/spec/decorators/view_context_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 def it_does_not_leak_view_context
   2.times do
-    it "has an independent view context" do
+    it 'has an independent view context' do
       expect(Draper::ViewContext.current).not_to be :leaked
       Draper::ViewContext.current = :leaked
     end
   end
 end
 
-describe "A decorator spec", type: :decorator do
+describe 'A decorator spec', type: :decorator do
   it_does_not_leak_view_context
 end
 
-describe "A controller spec", type: :controller do
+describe 'A controller spec', type: :controller do
   it_does_not_leak_view_context
 end
 
-describe "A mailer spec", type: :mailer do
+describe 'A mailer spec', type: :mailer do
   it_does_not_leak_view_context
 end

--- a/spec/dummy/spec/mailers/post_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/post_mailer_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
 describe PostMailer do
-  describe "#decorated_email" do
+  describe '#decorated_email' do
     let(:email_body) { Capybara.string(email.body.to_s) }
     let(:email) { PostMailer.decorated_email(post).deliver }
     let(:post) { Post.create }
 
-    it "decorates" do
-      expect(email_body).to have_content "Today"
+    it 'decorates' do
+      expect(email_body).to have_content 'Today'
     end
 
-    it "can use url helpers with a model" do
-      expect(email_body).to have_css "#url_with_model", text: "http://www.example.com:12345/en/posts/#{post.id}"
+    it 'can use url helpers with a model' do
+      expect(email_body).to have_css '#url_with_model', text: "http://www.example.com:12345/en/posts/#{post.id}"
     end
 
-    it "can use url helpers with an id" do
-      expect(email_body).to have_css "#url_with_id", text: "http://www.example.com:12345/en/posts/#{post.id}"
+    it 'can use url helpers with an id' do
+      expect(email_body).to have_css '#url_with_id', text: "http://www.example.com:12345/en/posts/#{post.id}"
     end
 
-    it "uses the correct view context controller" do
-      expect(email_body).to have_css "#controller", text: "PostMailer"
+    it 'uses the correct view context controller' do
+      expect(email_body).to have_css '#controller', text: 'PostMailer'
     end
   end
 end

--- a/spec/dummy/spec/models/mongoid_post_spec.rb
+++ b/spec/dummy/spec/models/mongoid_post_spec.rb
@@ -3,6 +3,6 @@ require 'shared_examples/decoratable'
 
 if defined?(Mongoid)
   describe MongoidPost do
-    it_behaves_like "a decoratable model"
+    it_behaves_like 'a decoratable model'
   end
 end

--- a/spec/dummy/spec/models/post_spec.rb
+++ b/spec/dummy/spec/models/post_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 require 'shared_examples/decoratable'
 
 describe Post do
-  it_behaves_like "a decoratable model"
+  it_behaves_like 'a decoratable model'
 end

--- a/spec/dummy/spec/shared_examples/decoratable.rb
+++ b/spec/dummy/spec/shared_examples/decoratable.rb
@@ -1,6 +1,6 @@
-shared_examples_for "a decoratable model" do
-  describe ".decorate" do
-    it "applies a collection decorator to a scope" do
+shared_examples_for 'a decoratable model' do
+  describe '.decorate' do
+    it 'applies a collection decorator to a scope' do
       described_class.create
       decorated = described_class.limit(1).decorate
 
@@ -9,7 +9,7 @@ shared_examples_for "a decoratable model" do
     end
   end
 
-  describe "#==" do
+  describe '#==' do
     it "is true for other instances' decorators" do
       described_class.create
       one = described_class.first

--- a/spec/dummy/test/decorators/minitest/devise_test.rb
+++ b/spec/dummy/test/decorators/minitest/devise_test.rb
@@ -1,36 +1,36 @@
 require 'minitest_helper'
 
 if defined?(Devise)
-  describe "A decorator test" do
-    it "can sign in a real user" do
+  describe 'A decorator test' do
+    it 'can sign in a real user' do
       user = User.new
       sign_in user
 
       assert_same user, helper.current_user
     end
 
-    it "can sign in a mock user" do
+    it 'can sign in a mock user' do
       user = Object.new
       sign_in :user, user
 
       assert_same user, helper.current_user
     end
 
-    it "can sign in a real admin" do
+    it 'can sign in a real admin' do
       admin = Admin.new
       sign_in admin
 
       assert_same admin, helper.current_admin
     end
 
-    it "can sign in a mock admin" do
+    it 'can sign in a mock admin' do
       admin = Object.new
       sign_in :admin, admin
 
       assert_same admin, helper.current_admin
     end
 
-    it "can sign out a real user" do
+    it 'can sign out a real user' do
       user = User.new
       sign_in user
       sign_out user
@@ -38,7 +38,7 @@ if defined?(Devise)
       assert helper.current_user.nil?
     end
 
-    it "can sign out a mock user" do
+    it 'can sign out a mock user' do
       user = Object.new
       sign_in :user, user
       sign_out :user
@@ -46,7 +46,7 @@ if defined?(Devise)
       assert helper.current_user.nil?
     end
 
-    it "can sign out without a user" do
+    it 'can sign out without a user' do
       sign_out :user
 
       assert helper.current_user.nil?

--- a/spec/dummy/test/decorators/minitest/helpers_test.rb
+++ b/spec/dummy/test/decorators/minitest/helpers_test.rb
@@ -1,19 +1,19 @@
 require 'minitest_helper'
 
-describe "A decorator test" do
-  it "can access helpers through `helper`" do
-    assert_equal "<p>Help!</p>", helper.content_tag(:p, "Help!")
+describe 'A decorator test' do
+  it 'can access helpers through `helper`' do
+    assert_equal '<p>Help!</p>', helper.content_tag(:p, 'Help!')
   end
 
-  it "can access helpers through `helpers`" do
-    assert_equal "<p>Help!</p>", helpers.content_tag(:p, "Help!")
+  it 'can access helpers through `helpers`' do
+    assert_equal '<p>Help!</p>', helpers.content_tag(:p, 'Help!')
   end
 
-  it "can access helpers through `h`" do
-    assert_equal "<p>Help!</p>", h.content_tag(:p, "Help!")
+  it 'can access helpers through `h`' do
+    assert_equal '<p>Help!</p>', h.content_tag(:p, 'Help!')
   end
 
-  it "gets the same helper object as a decorator" do
+  it 'gets the same helper object as a decorator' do
     decorator = Draper::Decorator.new(Object.new)
 
     assert_same decorator.helpers, helpers

--- a/spec/dummy/test/decorators/minitest/spec_type_test.rb
+++ b/spec/dummy/test/decorators/minitest/spec_type_test.rb
@@ -1,13 +1,13 @@
 require 'minitest_helper'
 
 def it_is_a_decorator_test
-  it "is a decorator test" do
+  it 'is a decorator test' do
     assert_kind_of Draper::TestCase, self
   end
 end
 
 def it_is_not_a_decorator_test
-  it "is not a decorator test" do
+  it 'is not a decorator test' do
     refute_kind_of Draper::TestCase, self
   end
 end
@@ -23,23 +23,23 @@ describe ProductsDecorator do
   it_is_a_decorator_test
 end
 
-describe "ProductDecorator" do
+describe 'ProductDecorator' do
   it_is_a_decorator_test
 end
 
-describe "AnyDecorator" do
+describe 'AnyDecorator' do
   it_is_a_decorator_test
 end
 
-describe "Any decorator" do
+describe 'Any decorator' do
   it_is_a_decorator_test
 end
 
-describe "AnyDecoratorTest" do
+describe 'AnyDecoratorTest' do
   it_is_a_decorator_test
 end
 
-describe "Any decorator test" do
+describe 'Any decorator test' do
   it_is_a_decorator_test
 end
 
@@ -47,6 +47,6 @@ describe Object do
   it_is_not_a_decorator_test
 end
 
-describe "Nope" do
+describe 'Nope' do
   it_is_not_a_decorator_test
 end

--- a/spec/dummy/test/decorators/minitest/view_context_test.rb
+++ b/spec/dummy/test/decorators/minitest/view_context_test.rb
@@ -2,23 +2,23 @@ require 'minitest_helper'
 
 def it_does_not_leak_view_context
   2.times do
-    it "has an independent view context" do
+    it 'has an independent view context' do
       refute_equal :leaked, Draper::ViewContext.current
       Draper::ViewContext.current = :leaked
     end
   end
 end
 
-describe "A decorator test" do
+describe 'A decorator test' do
   it_does_not_leak_view_context
 end
 
-describe "A controller decorator test" do
+describe 'A controller decorator test' do
   subject { Class.new(ActionController::Base) }
 
   it_does_not_leak_view_context
 end
 
-describe "A mailer decorator test" do
+describe 'A mailer decorator test' do
   it_does_not_leak_view_context
 end

--- a/spec/dummy/test/decorators/test_unit/helpers_test.rb
+++ b/spec/dummy/test/decorators/test_unit/helpers_test.rb
@@ -2,15 +2,15 @@ require 'test_helper'
 
 class HelpersTest < Draper::TestCase
   def test_access_helpers_through_helper
-    assert_equal "<p>Help!</p>", helper.content_tag(:p, "Help!")
+    assert_equal '<p>Help!</p>', helper.content_tag(:p, 'Help!')
   end
 
   def test_access_helpers_through_helpers
-    assert_equal "<p>Help!</p>", helpers.content_tag(:p, "Help!")
+    assert_equal '<p>Help!</p>', helpers.content_tag(:p, 'Help!')
   end
 
   def test_access_helpers_through_h
-    assert_equal "<p>Help!</p>", h.content_tag(:p, "Help!")
+    assert_equal '<p>Help!</p>', h.content_tag(:p, 'Help!')
   end
 
   def test_same_helper_object_as_decorators

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -5,7 +5,7 @@ require 'generators/controller_override'
 require 'generators/rails/decorator_generator'
 
 describe Rails::Generators::ControllerGenerator do
-  destination File.expand_path("../tmp", __FILE__)
+  destination File.expand_path('../tmp', __FILE__)
 
   before { prepare_destination }
   after(:all) { FileUtils.rm_rf destination_root }

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -10,13 +10,13 @@ describe Rails::Generators::ControllerGenerator do
   before { prepare_destination }
   after(:all) { FileUtils.rm_rf destination_root }
 
-  describe "the generated decorator" do
-    subject { file("app/decorators/your_model_decorator.rb") }
+  describe 'the generated decorator' do
+    subject { file('app/decorators/your_model_decorator.rb') }
 
-    describe "naming" do
+    describe 'naming' do
       before { run_generator %w(YourModels) }
 
-      it { is_expected.to contain "class YourModelDecorator" }
+      it { is_expected.to contain 'class YourModelDecorator' }
     end
   end
 end

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -4,7 +4,7 @@ require 'ammeter/init'
 require 'generators/rails/decorator_generator'
 
 describe Rails::Generators::DecoratorGenerator do
-  destination File.expand_path("../tmp", __FILE__)
+  destination File.expand_path('../tmp', __FILE__)
 
   before { prepare_destination }
   after(:all) { FileUtils.rm_rf destination_root }

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -9,84 +9,84 @@ describe Rails::Generators::DecoratorGenerator do
   before { prepare_destination }
   after(:all) { FileUtils.rm_rf destination_root }
 
-  describe "the generated decorator" do
-    subject { file("app/decorators/your_model_decorator.rb") }
+  describe 'the generated decorator' do
+    subject { file('app/decorators/your_model_decorator.rb') }
 
-    describe "naming" do
+    describe 'naming' do
       before { run_generator %w(YourModel) }
 
-      it { is_expected.to contain "class YourModelDecorator" }
+      it { is_expected.to contain 'class YourModelDecorator' }
     end
 
-    describe "namespacing" do
-      subject { file("app/decorators/namespace/your_model_decorator.rb") }
+    describe 'namespacing' do
+      subject { file('app/decorators/namespace/your_model_decorator.rb') }
       before { run_generator %w(Namespace::YourModel) }
 
-      it { is_expected.to contain "class Namespace::YourModelDecorator" }
+      it { is_expected.to contain 'class Namespace::YourModelDecorator' }
     end
 
-    describe "inheritance" do
-      context "by default" do
+    describe 'inheritance' do
+      context 'by default' do
         before { run_generator %w(YourModel) }
 
-        it { is_expected.to contain "class YourModelDecorator < Draper::Decorator" }
+        it { is_expected.to contain 'class YourModelDecorator < Draper::Decorator' }
       end
 
-      context "with the --parent option" do
+      context 'with the --parent option' do
         before { run_generator %w(YourModel --parent=FooDecorator) }
 
-        it { is_expected.to contain "class YourModelDecorator < FooDecorator" }
+        it { is_expected.to contain 'class YourModelDecorator < FooDecorator' }
       end
 
-      context "with an ApplicationDecorator" do
+      context 'with an ApplicationDecorator' do
         before do
           allow_any_instance_of(Object).to receive(:require)
-          allow_any_instance_of(Object).to receive(:require).with("application_decorator").and_return(
-            stub_const "ApplicationDecorator", Class.new
+          allow_any_instance_of(Object).to receive(:require).with('application_decorator').and_return(
+            stub_const 'ApplicationDecorator', Class.new
           )
         end
 
         before { run_generator %w(YourModel) }
 
-        it { is_expected.to contain "class YourModelDecorator < ApplicationDecorator" }
+        it { is_expected.to contain 'class YourModelDecorator < ApplicationDecorator' }
       end
     end
   end
 
-  context "with -t=rspec" do
-    describe "the generated spec" do
-      subject { file("spec/decorators/your_model_decorator_spec.rb") }
+  context 'with -t=rspec' do
+    describe 'the generated spec' do
+      subject { file('spec/decorators/your_model_decorator_spec.rb') }
 
-      describe "naming" do
+      describe 'naming' do
         before { run_generator %w(YourModel -t=rspec) }
 
-        it { is_expected.to contain "describe YourModelDecorator" }
+        it { is_expected.to contain 'describe YourModelDecorator' }
       end
 
-      describe "namespacing" do
-        subject { file("spec/decorators/namespace/your_model_decorator_spec.rb") }
+      describe 'namespacing' do
+        subject { file('spec/decorators/namespace/your_model_decorator_spec.rb') }
         before { run_generator %w(Namespace::YourModel -t=rspec) }
 
-        it { is_expected.to contain "describe Namespace::YourModelDecorator" }
+        it { is_expected.to contain 'describe Namespace::YourModelDecorator' }
       end
     end
   end
 
-  context "with -t=test_unit" do
-    describe "the generated test" do
-      subject { file("test/decorators/your_model_decorator_test.rb") }
+  context 'with -t=test_unit' do
+    describe 'the generated test' do
+      subject { file('test/decorators/your_model_decorator_test.rb') }
 
-      describe "naming" do
+      describe 'naming' do
         before { run_generator %w(YourModel -t=test_unit) }
 
-        it { is_expected.to contain "class YourModelDecoratorTest < Draper::TestCase" }
+        it { is_expected.to contain 'class YourModelDecoratorTest < Draper::TestCase' }
       end
 
-      describe "namespacing" do
-        subject { file("test/decorators/namespace/your_model_decorator_test.rb") }
+      describe 'namespacing' do
+        subject { file('test/decorators/namespace/your_model_decorator_test.rb') }
         before { run_generator %w(Namespace::YourModel -t=test_unit) }
 
-        it { is_expected.to contain "class Namespace::YourModelDecoratorTest < Draper::TestCase" }
+        it { is_expected.to contain 'class Namespace::YourModelDecoratorTest < Draper::TestCase' }
       end
     end
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 require 'support/dummy_app'
 require 'support/matchers/have_text'
 
-app = DummyApp.new(ENV["RAILS_ENV"])
+app = DummyApp.new(ENV['RAILS_ENV'])
 spec_types = {
-  view: ["/posts/1", "PostsController"],
-  mailer: ["/posts/1/mail", "PostMailer"]
+  view: ['/posts/1', 'PostsController'],
+  mailer: ['/posts/1/mail', 'PostMailer']
 }
 
 app.start_server do

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -13,56 +13,56 @@ app.start_server do
     page = app.get(path)
 
     describe "in a #{type}" do
-      it "runs in the correct environment" do
-        expect(page).to have_text(app.environment).in("#environment")
+      it 'runs in the correct environment' do
+        expect(page).to have_text(app.environment).in('#environment')
       end
 
-      it "uses the correct view context controller" do
-        expect(page).to have_text(controller).in("#controller")
+      it 'uses the correct view context controller' do
+        expect(page).to have_text(controller).in('#controller')
       end
 
-      it "can use built-in helpers" do
-        expect(page).to have_text("Once upon a...").in("#truncated")
+      it 'can use built-in helpers' do
+        expect(page).to have_text('Once upon a...').in('#truncated')
       end
 
-      it "can use built-in private helpers" do
+      it 'can use built-in private helpers' do
         # Nokogiri unescapes text!
-        expect(page).to have_text("<script>danger</script>").in("#html_escaped")
+        expect(page).to have_text('<script>danger</script>').in('#html_escaped')
       end
 
-      it "can use user-defined helpers from app/helpers" do
-        expect(page).to have_text("Hello, world!").in("#hello_world")
+      it 'can use user-defined helpers from app/helpers' do
+        expect(page).to have_text('Hello, world!').in('#hello_world')
       end
 
-      it "can use user-defined helpers from the controller" do
-        expect(page).to have_text("Goodnight, moon!").in("#goodnight_moon")
+      it 'can use user-defined helpers from the controller' do
+        expect(page).to have_text('Goodnight, moon!').in('#goodnight_moon')
       end
 
       # _path helpers aren't available in mailers
       if type == :view
-        it "can be passed to path helpers" do
-          expect(page).to have_text("/en/posts/1").in("#path_with_decorator")
+        it 'can be passed to path helpers' do
+          expect(page).to have_text('/en/posts/1').in('#path_with_decorator')
         end
 
-        it "can use path helpers with a model" do
-          expect(page).to have_text("/en/posts/1").in("#path_with_model")
+        it 'can use path helpers with a model' do
+          expect(page).to have_text('/en/posts/1').in('#path_with_model')
         end
 
-        it "can use path helpers with an id" do
-          expect(page).to have_text("/en/posts/1").in("#path_with_id")
+        it 'can use path helpers with an id' do
+          expect(page).to have_text('/en/posts/1').in('#path_with_id')
         end
       end
 
-      it "can be passed to url helpers" do
-        expect(page).to have_text("http://www.example.com:12345/en/posts/1").in("#url_with_decorator")
+      it 'can be passed to url helpers' do
+        expect(page).to have_text('http://www.example.com:12345/en/posts/1').in('#url_with_decorator')
       end
 
-      it "can use url helpers with a model" do
-        expect(page).to have_text("http://www.example.com:12345/en/posts/1").in("#url_with_model")
+      it 'can use url helpers with a model' do
+        expect(page).to have_text('http://www.example.com:12345/en/posts/1').in('#url_with_model')
       end
 
-      it "can use url helpers with an id" do
-        expect(page).to have_text("http://www.example.com:12345/en/posts/1").in("#url_with_id")
+      it 'can use url helpers with an id' do
+        expect(page).to have_text('http://www.example.com:12345/en/posts/1').in('#url_with_id')
       end
     end
   end

--- a/spec/performance/benchmark.rb
+++ b/spec/performance/benchmark.rb
@@ -3,28 +3,28 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
 Bundler.require :default
 
-require "benchmark"
-require "draper"
-require "./performance/models"
-require "./performance/decorators"
+require 'benchmark'
+require 'draper'
+require './performance/models'
+require './performance/decorators'
 
 Benchmark.bm do |bm|
   puts "\n[ Exclusivelly using #method_missing for model delegation ]"
   [ 1_000, 10_000, 100_000 ].each do |i|
     puts "\n[ #{i} ]"
-    bm.report("#new                 ") do
+    bm.report('#new                 ') do
       i.times do |n|
         ProductDecorator.decorate(Product.new)
       end
     end
 
-    bm.report("#hello_world         ") do
+    bm.report('#hello_world         ') do
       i.times do |n|
         ProductDecorator.decorate(Product.new).hello_world
       end
     end
 
-    bm.report("#sample_class_method ") do
+    bm.report('#sample_class_method ') do
       i.times do |n|
         ProductDecorator.decorate(Product.new).class.sample_class_method
       end
@@ -34,19 +34,19 @@ Benchmark.bm do |bm|
   puts "\n[ Defining methods on method_missing first hit ]"
   [ 1_000, 10_000, 100_000 ].each do |i|
     puts "\n[ #{i} ]"
-    bm.report("#new                 ") do
+    bm.report('#new                 ') do
       i.times do |n|
         FastProductDecorator.decorate(FastProduct.new)
       end
     end
 
-    bm.report("#hello_world         ") do
+    bm.report('#hello_world         ') do
       i.times do |n|
         FastProductDecorator.decorate(FastProduct.new).hello_world
       end
     end
 
-    bm.report("#sample_class_method ") do
+    bm.report('#sample_class_method ') do
       i.times do |n|
         FastProductDecorator.decorate(FastProduct.new).class.sample_class_method
       end

--- a/spec/performance/decorators.rb
+++ b/spec/performance/decorators.rb
@@ -2,7 +2,7 @@ require "./performance/models"
 class ProductDecorator < Draper::Decorator
 
   def awesome_title
-    "Awesome Title"
+    'Awesome Title'
   end
 
   # Original #method_missing
@@ -23,7 +23,7 @@ end
 class FastProductDecorator < Draper::Decorator
 
   def awesome_title
-    "Awesome Title"
+    'Awesome Title'
   end
 
   # Modified #method_missing

--- a/spec/performance/decorators.rb
+++ b/spec/performance/decorators.rb
@@ -1,4 +1,5 @@
-require "./performance/models"
+require './performance/models'
+
 class ProductDecorator < Draper::Decorator
 
   def awesome_title

--- a/spec/performance/models.rb
+++ b/spec/performance/models.rb
@@ -1,20 +1,20 @@
-require "./performance/active_record"
+require './performance/active_record'
 class Product < ActiveRecord::Base
   def self.sample_class_method
-    "sample class method"
+    'sample class method'
   end
 
   def hello_world
-    "Hello, World"
+    'Hello, World'
   end
 end
 
 class FastProduct < ActiveRecord::Base
   def self.sample_class_method
-    "sample class method"
+    'sample class method'
   end
 
   def hello_world
-    "Hello, World"
+    'Hello, World'
   end
 end

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -7,7 +7,7 @@ require 'net/http'
 class DummyApp
 
   def initialize(environment)
-    raise ArgumentError, "Environment must be development or production" unless ["development", "production"].include?(environment.to_s)
+    raise ArgumentError, 'Environment must be development or production' unless ['development', 'production'].include?(environment.to_s)
     @environment = environment
   end
 
@@ -49,8 +49,8 @@ class DummyApp
 
         yield
 
-        Process.kill("KILL", out.pid)
-        File.delete("tmp/pids/server.pid")
+        Process.kill('KILL', out.pid)
+        File.delete('tmp/pids/server.pid')
       end
     end
   end
@@ -58,11 +58,11 @@ class DummyApp
   private
 
   def root
-    File.expand_path("../../dummy", __FILE__)
+    File.expand_path('../../dummy', __FILE__)
   end
 
   def localhost
-    "127.0.0.1"
+    '127.0.0.1'
   end
 
   def port

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -30,7 +30,7 @@ class DummyApp
       IO.popen("bundle exec rails s -e #{@environment} -p #{port} 2>&1") do |out|
         start   = Time.now
         started = false
-        output  = ""
+        output  = ''
         timeout = 60.0
 
         while !started && !out.eof? && Time.now - start <= timeout
@@ -76,7 +76,7 @@ class DummyApp
 
   def read_output(stream)
     read = IO.select([stream], [], [stream], 0.1)
-    output = ""
+    output = ''
     loop { output << stream.read_nonblock(1024) } if read
     output
   rescue Errno::EAGAIN, Errno::EWOULDBLOCK, EOFError

--- a/spec/support/matchers/have_text.rb
+++ b/spec/support/matchers/have_text.rb
@@ -18,7 +18,7 @@ module HaveTextMatcher
     def matches?(subject)
       @subject = Capybara.string(subject)
 
-      @subject.has_css?(@css || "*", text: @text)
+      @subject.has_css?(@css || '*', text: @text)
     end
 
     def failure_message
@@ -40,7 +40,7 @@ module HaveTextMatcher
     end
 
     def inside
-      @css ? "inside #{@css.inspect}" : "anywhere"
+      @css ? "inside #{@css.inspect}" : 'anywhere'
     end
   end
 end

--- a/spec/support/shared_examples/decoratable_equality.rb
+++ b/spec/support/shared_examples/decoratable_equality.rb
@@ -1,37 +1,37 @@
-shared_examples_for "decoration-aware #==" do |subject|
-  it "is true for itself" do
+shared_examples_for 'decoration-aware #==' do |subject|
+  it 'is true for itself' do
     expect(subject == subject).to be_truthy
   end
 
-  it "is false for another object" do
+  it 'is false for another object' do
     expect(subject == Object.new).to be_falsey
   end
 
-  it "is true for a decorated version of itself" do
+  it 'is true for a decorated version of itself' do
     decorated = double(object: subject, decorated?: true)
 
     expect(subject == decorated).to be_truthy
   end
 
-  it "is false for a decorated other object" do
+  it 'is false for a decorated other object' do
     decorated = double(object: Object.new, decorated?: true)
 
     expect(subject == decorated).to be_falsey
   end
 
-  it "is false for a decoratable object with a `object` association" do
+  it 'is false for a decoratable object with a `object` association' do
     decoratable = double(object: subject, decorated?: false)
 
     expect(subject == decoratable).to be_falsey
   end
 
-  it "is false for an undecoratable object with a `object` association" do
+  it 'is false for an undecoratable object with a `object` association' do
     undecoratable = double(object: subject)
 
     expect(subject == undecoratable).to be_falsey
   end
 
-  it "is true for a multiply-decorated version of itself" do
+  it 'is true for a multiply-decorated version of itself' do
     decorated = double(object: subject, decorated?: true)
     redecorated = double(object: decorated, decorated?: true)
 

--- a/spec/support/shared_examples/view_helpers.rb
+++ b/spec/support/shared_examples/view_helpers.rb
@@ -1,37 +1,37 @@
-shared_examples_for "view helpers" do |subject|
-  describe "#helpers" do
-    it "returns the current view context" do
+shared_examples_for 'view helpers' do |subject|
+  describe '#helpers' do
+    it 'returns the current view context' do
       allow(Draper::ViewContext).to receive_messages current: :current_view_context
       expect(subject.helpers).to be :current_view_context
     end
 
-    it "is aliased to #h" do
+    it 'is aliased to #h' do
       allow(Draper::ViewContext).to receive_messages current: :current_view_context
       expect(subject.h).to be :current_view_context
     end
   end
 
-  describe "#localize" do
-    it "delegates to #helpers" do
+  describe '#localize' do
+    it 'delegates to #helpers' do
       allow(subject).to receive(:helpers).and_return(double)
-      expect(subject.helpers).to receive(:localize).with(:an_object, some: "parameter")
-      subject.localize(:an_object, some: "parameter")
+      expect(subject.helpers).to receive(:localize).with(:an_object, some: 'parameter')
+      subject.localize(:an_object, some: 'parameter')
     end
 
-    it "is aliased to #l" do
+    it 'is aliased to #l' do
       allow(subject).to receive_messages helpers: double
-      expect(subject.helpers).to receive(:localize).with(:an_object, some: "parameter")
-      subject.l(:an_object, some: "parameter")
+      expect(subject.helpers).to receive(:localize).with(:an_object, some: 'parameter')
+      subject.l(:an_object, some: 'parameter')
     end
   end
 
-  describe ".helpers" do
-    it "returns the current view context" do
+  describe '.helpers' do
+    it 'returns the current view context' do
       allow(Draper::ViewContext).to receive_messages current: :current_view_context
       expect(subject.class.helpers).to be :current_view_context
     end
 
-    it "is aliased to .h" do
+    it 'is aliased to .h' do
       allow(Draper::ViewContext).to receive(:current).and_return(:current_view_context)
       expect(subject.class.h).to be :current_view_context
     end


### PR DESCRIPTION
# Proposal request

## Description

I have noticed that some of string constants wrapped in double quotes, and some of them - in single quotes, so, my proposal is - use one approach to specify string constants and don't mix them.

## Things to discuss 

Double quotes vs single - which approach has better performance?

Example: 

https://github.com/vigetlabs/ruby-string-showdown