### PR TITLE
Refactor generator for TestUnit, RSpec

### DIFF
--- a/lib/generators/draper/install_generator.rb
+++ b/lib/generators/draper/install_generator.rb
@@ -1,7 +1,7 @@
 module Draper
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       desc 'Creates an ApplicationDecorator, if none exists.'
 

--- a/lib/generators/mini_test/decorator_generator.rb
+++ b/lib/generators/mini_test/decorator_generator.rb
@@ -4,7 +4,7 @@ module MiniTest
   module Generators
     class DecoratorGenerator < Base
       def self.source_root
-        File.expand_path('../templates', __FILE__)
+        File.expand_path("templates", __dir__)
       end
 
       class_option :spec, type: :boolean, default: false, desc: "Use MiniTest::Spec DSL"

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -1,7 +1,7 @@
 module Rails
   module Generators
     class DecoratorGenerator < NamedBase
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
       check_class_collision suffix: "Decorator"
 
       class_option :parent, type: :string, desc: "The parent class for the generated decorator"

--- a/lib/generators/rspec/decorator_generator.rb
+++ b/lib/generators/rspec/decorator_generator.rb
@@ -1,7 +1,7 @@
 module Rspec
   module Generators
     class DecoratorGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_spec_file
         template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{singular_name}_decorator_spec.rb")

--- a/lib/generators/rspec/decorator_generator.rb
+++ b/lib/generators/rspec/decorator_generator.rb
@@ -1,9 +1,11 @@
 module Rspec
-  class DecoratorGenerator < ::Rails::Generators::NamedBase
-    source_root File.expand_path('../templates', __FILE__)
+  module Generators
+    class DecoratorGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path('../templates', __FILE__)
 
-    def create_spec_file
-      template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{singular_name}_decorator_spec.rb")
+      def create_spec_file
+        template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{singular_name}_decorator_spec.rb")
+      end
     end
   end
 end

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -1,9 +1,12 @@
 module TestUnit
-  class DecoratorGenerator < ::Rails::Generators::NamedBase
-    source_root File.expand_path('../templates', __FILE__)
+  module Generators
+    class DecoratorGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path('../templates', __FILE__)
+      check_class_collision suffix: "DecoratorTest"
 
-    def create_test_file
-      template 'decorator_test.rb', File.join('test/decorators', class_path, "#{singular_name}_decorator_test.rb")
+      def create_test_file
+        template 'decorator_test.rb', File.join('test/decorators', class_path, "#{singular_name}_decorator_test.rb")
+      end
     end
   end
 end

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -1,7 +1,7 @@
 module TestUnit
   module Generators
     class DecoratorGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
       check_class_collision suffix: "DecoratorTest"
 
       def create_test_file


### PR DESCRIPTION
Refactored generators:

1. Add `check_class_collision suffix: "DecoratorTest"` to generator for TestUnit
2. Nested namespace `Generators` same as originals ([test_unit](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/test_unit.rb#L4), [rspec](https://github.com/rspec/rspec-rails/blob/master/lib/generators/rspec.rb#L9)]

I've checked running on rails application for sandbox. No problems.