### PR TITLE
Feature: ActiveJob Integration and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,11 +620,12 @@ you can include this module manually.
 
 ### Active Job Integration
 
-For integration with [Active Job](http://edgeguides.rubyonrails.org/active_job_basics.html), decorated objects will need to implement [Global ID](https://github.com/rails/globalid). Active Job allows you to pass ActiveRecord objects to background tasks directly and performs the necessary serialization and deserialization.  To add Global ID to all Draper decorated objects, add the following code to an initializer (e.g. `config/initializers/draper.rb`):
-
-```ruby
-Draper::Decorator.send(:include, GlobalID::Identification) if defined?(GlobalID)
-```
+[Active Job](http://edgeguides.rubyonrails.org/active_job_basics.html) allows you to pass ActiveRecord 
+objects to background tasks directly and performs the necessary serialization and deserialization. In
+order to do this, arguments to a background job must implement [Global ID](https://github.com/rails/globalid).
+Decorated objects implement Global ID by delegating to the object they are decorating. This means
+you can pass decorated objects to background jobs, however, the object won't be decorated when it is
+deserialized.
 
 ## Contributors
 

--- a/lib/draper/compatibility/global_id.rb
+++ b/lib/draper/compatibility/global_id.rb
@@ -1,0 +1,22 @@
+module Draper
+  module Compatibility
+    # [Active Job](http://edgeguides.rubyonrails.org/active_job_basics.html) allows you to pass
+    # ActiveRecord objects to background tasks directly and performs the necessary serialization
+    # and deserialization. In order to do this, arguments to a background job must implement
+    # [Global ID](https://github.com/rails/globalid).
+    #
+    # This compatibility patch implements Global ID for decorated objects by delegating to the object
+    # that is decorated. This means you can pass decorated objects to background jobs, but 
+    # the object won't be decorated when it is deserialized. This patch is meant as an intermediate
+    # fix until we can find a way to deserialize the decorated object correctly.
+    module GlobalID
+      extend ActiveSupport::Concern
+
+      included do
+        include ::GlobalID::Identification
+
+        delegate :to_global_id, :to_signed_global_id, to: :object
+      end
+    end
+  end
+end

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -1,6 +1,7 @@
 module Draper
   class Decorator
     include Draper::ViewHelpers
+    include Draper::Compatibility::GlobalID if defined?(GlobalID)
     extend Draper::Delegation
 
     include ActiveModel::Serialization

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -1,7 +1,9 @@
+require 'draper/compatibility/global_id'
+
 module Draper
   class Decorator
     include Draper::ViewHelpers
-    include Draper::Compatibility::GlobalID if defined?(GlobalID)
+    #include Draper::Compatibility::GlobalID if defined?(GlobalID)
     extend Draper::Delegation
 
     include ActiveModel::Serialization

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -3,7 +3,7 @@ require 'draper/compatibility/global_id'
 module Draper
   class Decorator
     include Draper::ViewHelpers
-    #include Draper::Compatibility::GlobalID if defined?(GlobalID)
+    include Draper::Compatibility::GlobalID if defined?(GlobalID)
     extend Draper::Delegation
 
     include ActiveModel::Serialization

--- a/spec/dummy/app/jobs/publish_post_job.rb
+++ b/spec/dummy/app/jobs/publish_post_job.rb
@@ -2,6 +2,6 @@ class PublishPostJob < ActiveJob::Base
   queue_as :default
 
   def perform(post)
-    Rails.logger.debug "Publishing post: #{post.id} of type #{post.class}"
+    post.save!
   end
 end

--- a/spec/dummy/app/jobs/publish_post_job.rb
+++ b/spec/dummy/app/jobs/publish_post_job.rb
@@ -1,0 +1,7 @@
+class PublishPostJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(post)
+    Rails.logger.debug "Publishing post: #{post.id} of type #{post.class}"
+  end
+end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -28,4 +28,6 @@ Dummy::Application.configure do
   config.active_support.deprecation = :stderr
 
   config.eager_load = false
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/dummy/spec/jobs/publish_post_job_spec.rb
+++ b/spec/dummy/spec/jobs/publish_post_job_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe PublishPostJob, type: :job do
   let(:post) { Post.create.decorate }
 
   subject(:job) { described_class.perform_later(post) }
-  
+
   it 'queues the job' do
-  	expect { job }.to have_enqueued_job(described_class).with(post.object)
+    expect { job }.to have_enqueued_job(described_class).with(post.object)
   end
 end

--- a/spec/dummy/spec/jobs/publish_post_job_spec.rb
+++ b/spec/dummy/spec/jobs/publish_post_job_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe PublishPostJob, type: :job do
-  let(:post) { Post.first.decorate }
+  let(:post) { Post.create.decorate }
 
   subject(:job) { described_class.perform_later(post) }
   

--- a/spec/dummy/spec/jobs/publish_post_job_spec.rb
+++ b/spec/dummy/spec/jobs/publish_post_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe PublishPostJob, type: :job do
+  let(:post) { Post.first.decorate }
+
+  subject(:job) { described_class.perform_later(post) }
+  
+  it 'queues the job' do
+  	expect { job }.to have_enqueued_job(described_class).with(post.object)
+  end
+end

--- a/spec/dummy/spec/models/post_spec.rb
+++ b/spec/dummy/spec/models/post_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
 require 'shared_examples/decoratable'
 
-describe Post do
-  it_behaves_like "a decoratable model"
+RSpec.describe Post do
+  it_behaves_like 'a decoratable model'
 
   it { should be_a ApplicationRecord }
+
+  describe '#to_global_id' do
+    let(:post) { Post.create }
+    subject { post.to_global_id }
+
+    it { is_expected.to eq post.decorate.to_global_id }
+  end
 end


### PR DESCRIPTION
## Description
This pull request makes it so that decorators implement `GlobalID` so they can be passed to background jobs. While you can now pass a decorated object to a background job, it won't be decorated when it is deserialized. This may lead to some confusion, so it is documented in the README.

## Testing

Try to pass a decorated object to a background job and it should no longer throw `ActiveJob::SerializationError`.

## To-Dos
- [x] tests
- [x] documentation

## References
* [GitHub Issue 663](https://github.com/drapergem/draper/issues/663)
* [GitHub Pull Request #669 containing initial documentation](https://github.com/drapergem/draper/pull/669)