### PR TITLE
Let decorator_class infer anonymous class' decorator from superclass

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -72,9 +72,9 @@ module Draper
       def decorator_class
         prefix = respond_to?(:model_name) ? model_name : name
         decorator_name = "#{prefix}Decorator"
-        decorator_name.constantize
-      rescue NameError => error
-        raise unless error.missing_name?(decorator_name)
+        decorator_name_constant = decorator_name.safe_constantize
+        return decorator_name_constant unless decorator_name_constant.nil?
+
         if superclass.respond_to?(:decorator_class)
           superclass.decorator_class
         else

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -222,11 +222,9 @@ module Draper
     # @return [Class] the class created by {decorate_collection}.
     def self.collection_decorator_class
       name = collection_decorator_name
-      name_constant = name.safe_constantize
+      name_constant = name && name.safe_constantize
 
       name_constant || Draper::CollectionDecorator
-    rescue NameError
-      Draper::CollectionDecorator
     end
 
     private
@@ -241,25 +239,23 @@ module Draper
     end
 
     def self.object_class_name
-      raise NameError if name.nil? || name.demodulize !~ /.+Decorator$/
+      return nil if name.nil? || name.demodulize !~ /.+Decorator$/
       name.chomp("Decorator")
     end
 
     def self.inferred_object_class
       name = object_class_name
-      name_constant = name.safe_constantize
+      name_constant = name && name.safe_constantize
       raise Draper::UninferrableObjectError.new(self) if name_constant.nil?
 
       name_constant
-    rescue NameError => error
-      raise if name && !error.missing_name?(name)
-      raise Draper::UninferrableObjectError.new(self)
     end
 
     def self.collection_decorator_name
-      plural = object_class_name.pluralize
-      raise NameError if plural == object_class_name
-      "#{plural}Decorator"
+      singular = object_class_name
+      plural = singular && singular.pluralize
+
+      plural == singular ? nil : "#{plural}Decorator"
     end
 
     def handle_multiple_decoration(options)

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -246,16 +246,16 @@ module Draper
     def self.inferred_object_class
       name = object_class_name
       name_constant = name && name.safe_constantize
-      raise Draper::UninferrableObjectError.new(self) if name_constant.nil?
+      return name_constant unless name_constant.nil?
 
-      name_constant
+      raise Draper::UninferrableObjectError.new(self)
     end
 
     def self.collection_decorator_name
       singular = object_class_name
       plural = singular && singular.pluralize
 
-      plural == singular ? nil : "#{plural}Decorator"
+      "#{plural}Decorator" unless plural == singular
     end
 
     def handle_multiple_decoration(options)

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -222,7 +222,9 @@ module Draper
     # @return [Class] the class created by {decorate_collection}.
     def self.collection_decorator_class
       name = collection_decorator_name
-      name.constantize
+      name_constant = name.safe_constantize
+
+      name_constant || Draper::CollectionDecorator
     rescue NameError
       Draper::CollectionDecorator
     end
@@ -245,7 +247,10 @@ module Draper
 
     def self.inferred_object_class
       name = object_class_name
-      name.constantize
+      name_constant = name.safe_constantize
+      raise Draper::UninferrableObjectError.new(self) if name_constant.nil?
+
+      name_constant
     rescue NameError => error
       raise if name && !error.missing_name?(name)
       raise Draper::UninferrableObjectError.new(self)

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -205,8 +205,20 @@ module Draper
 
       context "when an unrelated NameError is thrown" do
         it "re-raises that error" do
-          allow_any_instance_of(String).to receive(:constantize) { Draper::Base }
+          # Not related to safe_constantize behavior, we just want to raise a NameError inside the function
+          allow_any_instance_of(String).to receive(:safe_constantize) { Draper::Base }
           expect{Product.decorator_class}.to raise_error NameError, /Draper::Base/
+        end
+      end
+
+      context "when an anonymous class is given" do
+        it "infers the decorator from a superclass" do
+          anonymous_class = Class.new(Product) do
+            def self.name
+              to_s
+            end
+          end
+          expect(anonymous_class.decorator_class).to be ProductDecorator
         end
       end
     end

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -225,7 +225,7 @@ module Draper
 
     describe '.collection_decorator_class' do
       it 'defaults to CollectionDecorator' do
-        allow_any_instance_of(String).to receive(:constantize) { SomethingThatDoesntExist }
+        allow_any_instance_of(String).to receive(:safe_constantize) { nil }
         expect(ProductDecorator.collection_decorator_class).to be Draper::CollectionDecorator
       end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -202,7 +202,8 @@ module Draper
 
         context "when an unrelated NameError is thrown" do
           it "re-raises that error" do
-            allow_any_instance_of(String).to receive(:constantize) { SomethingThatDoesntExist }
+            # Not related to safe_constantize behavior, we just want to raise a NameError inside the function
+            allow_any_instance_of(String).to receive(:safe_constantize) { SomethingThatDoesntExist }
             expect{ProductDecorator.object_class}.to raise_error NameError, /SomethingThatDoesntExist/
           end
         end


### PR DESCRIPTION
## Description
Since Rails 5, draper gem gets some issues of raising `NameError` on inferring decorator class (https://github.com/drapergem/draper/issues/773). The previous PR (https://github.com/drapergem/draper/pull/795) fixes this issue when using `decorate_collection`, but this issue can also happen when using `decorate`, and we encountered this issue on our production code when upgrading to Rails 5.

I tried to replace `constantize` with `safe_constantize` in this PR, so we don't need to rescue and check if the `NameError` was caused by draper itself anymore. It should be safer than previous approach.

Thanks.

## References
* [GitHub Issue #773 ](https://github.com/drapergem/draper/issues/773)
* [GitHub Pull Request #795 ](https://github.com/drapergem/draper/pull/795)
