### PR TITLE
When decoration fails, show original class

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -69,16 +69,16 @@ module Draper
       # `Product` maps to `ProductDecorator`).
       #
       # @return [Class] the inferred decorator class.
-      def decorator_class
+      def decorator_class(called_on = self)
         prefix = respond_to?(:model_name) ? model_name : name
         decorator_name = "#{prefix}Decorator"
         decorator_name_constant = decorator_name.safe_constantize
         return decorator_name_constant unless decorator_name_constant.nil?
 
         if superclass.respond_to?(:decorator_class)
-          superclass.decorator_class
+          superclass.decorator_class(called_on)
         else
-          raise Draper::UninferrableDecoratorError.new(self)
+          raise Draper::UninferrableDecoratorError.new(called_on)
         end
       end
 

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -73,6 +73,16 @@ module Draper
         expect(Product).to receive(:decorator_class).and_return(:some_decorator)
         expect(product.decorator_class).to be :some_decorator
       end
+
+      it "specifies the class that #decorator_class was first called on (superclass)" do
+        person = Person.new
+        expect { person.decorator_class }.to raise_error(Draper::UninferrableDecoratorError, 'Could not infer a decorator for Person.')
+      end
+
+      it "specifies the class that #decorator_class was first called on (subclass)" do
+        child = Child.new
+        expect { child.decorator_class }.to raise_error(Draper::UninferrableDecoratorError, 'Could not infer a decorator for Child.')
+      end
     end
 
     describe "#==" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ class Model; include Draper::Decoratable; end
 class Product < Model; end
 class SpecialProduct < Product; end
 class Other < Model; end
+class Person < Model; end
+class Child < Person; end
 class ProductDecorator < Draper::Decorator; end
 class ProductsDecorator < Draper::CollectionDecorator; end
 


### PR DESCRIPTION
## Description
Thanks for the work on Draper to all the maintainers 👍

This provides a fix for #819 

When decorating an object without decorator, then the last class which was checked for a decorator is contained in the error message. In case of Rails this is most often `ActiveRecord::Base`.
This is a bit misleading and it would be better if the class which was actually tried to decorate is shown in the error message.
This is caused by the recursive nature of the `decorate` method which moves up  the hierarchy when no decorator class found. And raises when it can not move further up.


Before:

```ruby
Something::Bar.decorate
Draper::UninferrableDecoratorError: Could not infer a decorator for ActiveRecord::Base.
```

After:

```ruby
Something::Bar.decorate
Draper::UninferrableDecoratorError: Could not infer a decorator for Something::Bar.

```
## Testing
Outline steps to test your changes.

* Run the specs, tests have been added

Alternatively:
* on a subclass of AR, which does not have a decorator, call #decorate
* Check that the name of the subclass is contained in the error message and not `ActiveRecord::Base`

(The fix is not restricted to AR)

## References
* https://github.com/drapergem/draper/issues/819
