### PR TITLE
Update rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
   - mongodb
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 
 matrix:


### PR DESCRIPTION
Update rubies for travis ci:

* Ruby 2.2.7 to 2.2.8
* Ruby 2.3.4 to 2.3.5
* Ruby 2.4.1 to 2.4.2

For now, I will just skip 2.5.0-preview1. It should covered by ruby-head by now.