### PR TITLE
use current module's namespace for decorates_association

### DIFF
--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -15,12 +15,12 @@ module Draper
     # @param [Hash] options
     #   see {Decorator#initialize}
     def decorate(options = {})
-      decorator_class.decorate(self, options)
+      decorator_class(namespace: options.delete(:namespace)).decorate(self, options)
     end
 
     # (see ClassMethods#decorator_class)
-    def decorator_class
-      self.class.decorator_class
+    def decorator_class(namespace: nil)
+      self.class.decorator_class(namespace: namespace)
     end
 
     def decorator_class?
@@ -56,7 +56,7 @@ module Draper
       # @param [Hash] options
       #   see {Decorator.decorate_collection}.
       def decorate(options = {})
-        decorator_class.decorate_collection(all, options.reverse_merge(with: nil))
+        decorator_class(namespace: options[:namespace]).decorate_collection(all, options.reverse_merge(with: nil))
       end
 
       def decorator_class?
@@ -69,9 +69,11 @@ module Draper
       # `Product` maps to `ProductDecorator`).
       #
       # @return [Class] the inferred decorator class.
-      def decorator_class(called_on = self)
+      def decorator_class(called_on = self, namespace: nil)
         prefix = respond_to?(:model_name) ? model_name : name
-        decorator_name = "#{prefix}Decorator"
+        namespace = "#{namespace}::" if namespace.present?
+
+        decorator_name = "#{namespace}#{prefix}Decorator"
         decorator_name_constant = decorator_name.safe_constantize
         return decorator_name_constant unless decorator_name_constant.nil?
 

--- a/lib/draper/decorated_association.rb
+++ b/lib/draper/decorated_association.rb
@@ -12,7 +12,7 @@ module Draper
 
       decorator_class = options[:with]
       context = options.fetch(:context, ->(context){ context })
-      @factory = Draper::Factory.new(with: decorator_class, context: context)
+      @factory = Draper::Factory.new(with: decorator_class, context: context, namespace: owner.namespace)
     end
 
     def call

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -138,7 +138,8 @@ module Draper
     #   extra data to be stored in the collection decorator.
     def self.decorate_collection(object, options = {})
       options.assert_valid_keys(:with, :context)
-      collection_decorator_class.new(object, options.reverse_merge(with: self))
+      options[:with] ||= self
+      collection_decorator_class.new(object, options)
     end
 
     # @return [Array<Class>] the list of decorators that have been applied to
@@ -214,6 +215,10 @@ module Draper
     # implemented by the decorator.
     def attributes
       object.attributes.select {|attribute, _| respond_to?(attribute) }
+    end
+
+    def namespace
+      self.class.to_s.deconstantize.presence
     end
 
     # ActiveModel compatibility

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -198,6 +198,12 @@ module Draper
         end
       end
 
+      context "when namespace is passed explicitly" do
+        it "returns namespaced decorator class" do
+          expect(Product.decorator_class(namespace: Namespaced)).to be Namespaced::ProductDecorator
+        end
+      end
+
       context "when the decorator contains name error" do
         it "throws an NameError" do
           # We imitate ActiveSupport::Autoload behavior here in order to cause lazy NameError exception raising

--- a/spec/draper/decorated_association_spec.rb
+++ b/spec/draper/decorated_association_spec.rb
@@ -16,14 +16,14 @@ module Draper
       it "creates a factory" do
         options = {with: Decorator, context: {foo: "bar"}}
 
-        expect(Factory).to receive(:new).with(options)
-        DecoratedAssociation.new(double, :association, options)
+        expect(Factory).to receive(:new).with(options.merge(namespace: nil))
+        DecoratedAssociation.new(double(namespace: nil), :association, options)
       end
 
       describe ":with option" do
         it "defaults to nil" do
-          expect(Factory).to receive(:new).with(with: nil, context: anything())
-          DecoratedAssociation.new(double, :association, {})
+          expect(Factory).to receive(:new).with(with: nil, context: anything(), namespace: nil)
+          DecoratedAssociation.new(double(namespace: nil), :association, {})
         end
       end
 
@@ -32,7 +32,7 @@ module Draper
           expect(Factory).to receive(:new) do |options|
             options[:context].call(:anything) == :anything
           end
-          DecoratedAssociation.new(double, :association, {})
+          DecoratedAssociation.new(double(namespace: nil), :association, {})
         end
       end
     end
@@ -44,7 +44,7 @@ module Draper
         associated = double
         owner_context = {foo: "bar"}
         object = double(association: associated)
-        owner = double(object: object, context: owner_context)
+        owner = double(object: object, context: owner_context, namespace: nil)
         decorated_association = DecoratedAssociation.new(owner, :association, {})
         decorated = double
 
@@ -55,7 +55,7 @@ module Draper
       it "memoizes" do
         factory = double
         allow(Factory).to receive_messages(new: factory)
-        owner = double(object: double(association: double), context: {})
+        owner = double(object: double(association: double), context: {}, namespace: nil)
         decorated_association = DecoratedAssociation.new(owner, :association, {})
         decorated = double
 
@@ -70,7 +70,7 @@ module Draper
           allow(Factory).to receive_messages(new: factory)
           scoped = double
           object = double(association: double(applied_scope: scoped))
-          owner = double(object: object, context: {})
+          owner = double(object: object, context: {}, namespace: nil)
           decorated_association = DecoratedAssociation.new(owner, :association, scope: :applied_scope)
           decorated = double
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -471,6 +471,21 @@ module Draper
       end
     end
 
+    describe "#namespace" do
+      it "returns own module nesting" do
+        decorator = Namespaced::ProductDecorator.new(double)
+        expect(decorator.namespace).to eq("Namespaced")
+      end
+
+      context "when class has no nesting" do
+        it "returns nil" do
+          ::TopLevelDecorator = Class.new(Draper::Decorator)
+          decorator = TopLevelDecorator.new(double)
+          expect(decorator.namespace).to eq(nil)
+        end
+      end
+    end
+
     describe ".model_name" do
       it "delegates to the object class" do
         allow(Decorator).to receive(:object_class).and_return(double(model_name: :delegated))

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -35,7 +35,7 @@ module Draper
         factory = Factory.new
         object = double
 
-        expect(Factory::Worker).to receive(:new).with(anything(), object).and_return(->(*){})
+        expect(Factory::Worker).to receive(:new).with(anything(), object, anything()).and_return(->(*){})
         factory.decorate(object)
       end
 
@@ -44,7 +44,7 @@ module Draper
           decorator_class = double
           factory = Factory.new(with: decorator_class)
 
-          expect(Factory::Worker).to receive(:new).with(decorator_class, anything()).and_return(->(*){})
+          expect(Factory::Worker).to receive(:new).with(decorator_class, anything(), anything()).and_return(->(*){})
           factory.decorate(double)
         end
       end
@@ -53,7 +53,7 @@ module Draper
         it "passes nil to the worker" do
           factory = Factory.new
 
-          expect(Factory::Worker).to receive(:new).with(nil, anything()).and_return(->(*){})
+          expect(Factory::Worker).to receive(:new).with(nil, anything(), anything()).and_return(->(*){})
           factory.decorate(double)
         end
       end
@@ -97,7 +97,7 @@ module Draper
       it "calls the decorator method" do
         object = double
         options = {foo: "bar"}
-        worker = Factory::Worker.new(double, object)
+        worker = Factory::Worker.new(double, object, nil)
         decorator = ->(*){}
         allow(worker).to receive(:decorator){ decorator }
 
@@ -107,7 +107,7 @@ module Draper
 
       context "when the :context option is callable" do
         it "calls it" do
-          worker = Factory::Worker.new(double, double)
+          worker = Factory::Worker.new(double, double, nil)
           decorator = ->(*){}
           allow(worker).to receive_messages decorator: decorator
           context = {foo: "bar"}
@@ -117,7 +117,7 @@ module Draper
         end
 
         it "receives arguments from the :context_args option" do
-          worker = Factory::Worker.new(double, double)
+          worker = Factory::Worker.new(double, double, nil)
           allow(worker).to receive_messages decorator: ->(*){}
           context = ->{}
 
@@ -126,7 +126,7 @@ module Draper
         end
 
         it "wraps non-arrays passed to :context_args" do
-          worker = Factory::Worker.new(double, double)
+          worker = Factory::Worker.new(double, double, nil)
           allow(worker).to receive_messages decorator: ->(*){}
           context = ->{}
           hash = {foo: "bar"}
@@ -138,7 +138,7 @@ module Draper
 
       context "when the :context option is not callable" do
         it "doesn't call it" do
-          worker = Factory::Worker.new(double, double)
+          worker = Factory::Worker.new(double, double, nil)
           decorator = ->(*){}
           allow(worker).to receive_messages decorator: decorator
           context = {foo: "bar"}
@@ -149,7 +149,7 @@ module Draper
       end
 
       it "does not pass the :context_args option to the decorator" do
-        worker = Factory::Worker.new(double, double)
+        worker = Factory::Worker.new(double, double, nil)
         decorator = ->(*){}
         allow(worker).to receive_messages decorator: decorator
 
@@ -163,7 +163,7 @@ module Draper
         context "when decorator_class is specified" do
           it "returns the .decorate method from the decorator" do
             decorator_class = Class.new(Decorator)
-            worker = Factory::Worker.new(decorator_class, double)
+            worker = Factory::Worker.new(decorator_class, double, nil)
 
             expect(worker.decorator).to eq decorator_class.method(:decorate)
           end
@@ -174,9 +174,9 @@ module Draper
             it "returns the object's #decorate method" do
               object = double
               options = {foo: "bar"}
-              worker = Factory::Worker.new(nil, object)
+              worker = Factory::Worker.new(nil, object, nil)
 
-              expect(object).to receive(:decorate).with(options).and_return(:decorated)
+              expect(object).to receive(:decorate).with(options.merge(namespace: nil)).and_return(:decorated)
               expect(worker.decorator.call(object, options)).to be :decorated
             end
           end
@@ -184,7 +184,7 @@ module Draper
           context "and the object is not decoratable" do
             it "raises an error" do
               object = double
-              worker = Factory::Worker.new(nil, object)
+              worker = Factory::Worker.new(nil, object, nil)
 
               expect{worker.decorator}.to raise_error UninferrableDecoratorError
             end
@@ -196,7 +196,7 @@ module Draper
             object = Struct.new(:stuff).new("things")
 
             decorator_class = Class.new(Decorator)
-            worker = Factory::Worker.new(decorator_class, object)
+            worker = Factory::Worker.new(decorator_class, object, nil)
 
             expect(worker.decorator).to eq decorator_class.method(:decorate)
           end
@@ -207,7 +207,7 @@ module Draper
         context "when decorator_class is a CollectionDecorator" do
           it "returns the .decorate method from the collection decorator" do
             decorator_class = Class.new(CollectionDecorator)
-            worker = Factory::Worker.new(decorator_class, [])
+            worker = Factory::Worker.new(decorator_class, [], nil)
 
             expect(worker.decorator).to eq decorator_class.method(:decorate)
           end
@@ -216,7 +216,7 @@ module Draper
         context "when decorator_class is a Decorator" do
           it "returns the .decorate_collection method from the decorator" do
             decorator_class = Class.new(Decorator)
-            worker = Factory::Worker.new(decorator_class, [])
+            worker = Factory::Worker.new(decorator_class, [], nil)
 
             expect(worker.decorator).to eq decorator_class.method(:decorate_collection)
           end
@@ -229,7 +229,7 @@ module Draper
               decorator_class = Class.new(Decorator)
               allow(object).to receive(:decorator_class){ decorator_class }
               allow(object).to receive(:decorate){ nil }
-              worker = Factory::Worker.new(nil, object)
+              worker = Factory::Worker.new(nil, object, nil)
 
               expect(decorator_class).to receive(:decorate_collection).with(object, foo: "bar", with: nil).and_return(:decorated)
               expect(worker.decorator.call(object, foo: "bar")).to be :decorated
@@ -238,7 +238,7 @@ module Draper
 
           context "and the object is not decoratable" do
             it "returns the .decorate method from CollectionDecorator" do
-              worker = Factory::Worker.new(nil, [])
+              worker = Factory::Worker.new(nil, [], nil)
 
               expect(worker.decorator).to eq CollectionDecorator.method(:decorate)
             end


### PR DESCRIPTION
## Description
I have the same issue as author of the issue #809: Our app has two set of decorators: top level decorators and `Admin::*` decorators. Right now I have to explicitly specify `:with` option for every `decorates_association` call inside my admin decorators. This PR helps to simplify the process. All associations will be decorated using decorators from the same namespace as current decorator. 
#### Bonus: 
It is now possible to decorate object with namespaced decorator using `object.decorate(namespace: "Admin"` method instead of using `Admin::ObjectDecorator.new(object)` approach which is harder to automate.

I don't like my current implementation too much. All that passing of `:namespace` option from `DecoratedAssociation#initialize` deep into `Decoratable.decorator_class`looks too complicated . It would be easier to build namespaced decorator class name inside `DecoratedAssociation#initialize` and set it as value of `:with` option (if not present). This approach would look a lot cleaner but from architectural point of view it seems wrong because it is not `DecoratedAssociation`'s responsibility to build decorator class names.

## Testing
You can use any rails project that has `has_many->belongs_to` relation to test this feature. Let's assume that you have `User` model that `has_many :comments`. Sounds a bit too familiar, eh? 😄 
```ruby
# app/decorators/admin/user_decorator.rb
class Admin::UserDecorator < Draper::Decorator
  decorates_association :comments
end

# app/decorators/admin/comment_decorator.rb
class Admin::CommentDecorator < Draper::Decorator
  decorates_association :user
end

comment = Comment.first.decorate(namespace: "Admin")
decorated_comment.class # => Admin::CommentDecorator

decorated_user = decorated_comment.user
decorated_user.class # => Admin::UserDecorator

decorated_comment = decorated_user.comments.first
decorated_comment.class # => Admin::CommentDecorator
```


## To-Dos
- Check if we need to document this feature in README

## References
[Issue #809](https://github.com/drapergem/draper/issues/809)
