### PR TITLE
Move view context clear to before_setup (minitest)

### DIFF
--- a/lib/draper/test_case.rb
+++ b/lib/draper/test_case.rb
@@ -3,9 +3,9 @@ module Draper
 
   class TestCase < ::ActiveSupport::TestCase
     module ViewContextTeardown
-      def teardown
-        super
+      def before_setup
         Draper::ViewContext.clear!
+        super
       end
     end
 


### PR DESCRIPTION
We are using Draper with Minitest and experiencing the "leakage" of mailer view contexts into decorator tests. See #814 and related.

Draper does attempt to prevent the leakage by clearing the view context in a `teardown` hook, but this isn't effective. We are still seeing the problem.

This PR moves the clearing from `teardown` to `before_setup`, which properly resolves the leakage.