### PR TITLE
Rails 6 Support

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -17,17 +17,17 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency 'activesupport', '~> 5.0'
-  s.add_dependency 'actionpack', '~> 5.0'
-  s.add_dependency 'request_store', '~> 1.0'
-  s.add_dependency 'activemodel', '~> 5.0'
-  s.add_dependency 'activemodel-serializers-xml', '~> 1.0'
+  s.add_dependency 'activesupport', '>= 5.0'
+  s.add_dependency 'actionpack', '>= 5.0'
+  s.add_dependency 'request_store', '>= 1.0'
+  s.add_dependency 'activemodel', '>= 5.0'
+  s.add_dependency 'activemodel-serializers-xml', '>= 1.0'
 
   s.add_development_dependency 'ammeter'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'minitest-rails'
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'active_model_serializers', '~> 0.10'
+  s.add_development_dependency 'active_model_serializers', '>= 0.10'
   s.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
## Description
The current gemspec restricts Draper to Rails versions no higher than 5.x.

This change to the gemspec allows any versions including or greater than 5.x, and as such allows Draper to be used with Rails 6.

I'm using this branch against an actively developed project which we're now developing against Rails 6 with no issues so far.

## Testing
Existing tests should suffice as there are no changes in Rails 6 which should affect Draper.
