### PR TITLE
Fix indent

### DIFF
--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -11,7 +11,7 @@ module Draper
 
         expect(decorator).to be_a ProductDecorator
         expect(decorator.object).to be product
-     end
+      end
 
       it "accepts context" do
         context = {some: "context"}


### PR DESCRIPTION
## Description
Indent of `end` is different from that of accompanying `it` clause.
So I fixed it.
