### PR TITLE
Document the fix for view context leaking in specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ following to your `spec_helper` for each type of spec you are experiencing the l
 config.before(:each, type: :type) { Draper::ViewContext.clear! }
 ```
 
-Note: The `:type` above is just a placeholder. Replace `:type` with the type of spec you are experiencing
+_Note_: The `:type` above is just a placeholder. Replace `:type` with the type of spec you are experiencing
 the leakage from.
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -474,6 +474,20 @@ preferred stubbing technique (this example uses RSpec's `stub` method):
 helpers.stub(users_path: '/users')
 ```
 
+### View context leakage
+As mentioned before, Draper needs to build a view context to access helper methods. In MiniTest, the view context is
+cleared during `before_setup` preventing any view context leakage. In RSpec, the view context is cleared before each
+`decorator`, `controller`, and `mailer` spec. However, if you use decorators in other types of specs
+(e.g. `job`), you may still experience the view context leaking from the previous spec. To solve this, add the
+following to your `spec_helper` for each type of spec you are experiencing the leakage:
+
+```ruby
+config.before(:each, type: :type) { Draper::ViewContext.clear! }
+```
+
+Note: The `:type` above is just a placeholder. Replace `:type` with the type of spec you are experiencing
+the leakage from.
+
 ## Advanced usage
 
 ### Shared Decorator Methods


### PR DESCRIPTION
## Description
This pull request adds documentation for fixing the view context leakage between specs. I wanted to start with a documentation fix and go from there. If we later determine we need to clear the view context for all spec types by default, we can remove this documentation. See the referenced issue for the complete history of the issue.

## Testing
N/A

## To-Dos
None

## References
* [Should automatically clear view_context before/after each spec](https://github.com/drapergem/draper/issues/814)