### PR TITLE
fix: Don't delegate public methods overridden by a private in the decorator

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -20,6 +20,8 @@ module Draper
 
     # @private
     def delegatable?(method)
+      return if private_methods.include?(method)
+
       object.respond_to?(method)
     end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -665,7 +665,7 @@ module Draper
           expect(decorator.methods).not_to include :hello_world
         end
 
-        context 'When decorator overrides a public method defined on the object with a private' do
+        context 'when decorator overrides a public method defined on the object with a private' do
           let(:decorator_class) do
             Class.new(Decorator) do
               private

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -676,7 +676,7 @@ module Draper
             end
           end
 
-          let(:object) { Class.new{ def hello_world; end }.new }
+          let(:object) { Class.new { def hello_world; end }.new }
 
           it 'does not delegate the public method defined on the object' do
             decorator = decorator_class.new(object)

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -664,6 +664,26 @@ module Draper
           expect{decorator.hello_world}.to raise_error NoMethodError
           expect(decorator.methods).not_to include :hello_world
         end
+
+        context 'When decorator overrides a public method defined on the object with a private' do
+          let(:decorator_class) do
+            Class.new(Decorator) do
+              private
+
+              def hello_world
+                'hello world'
+              end
+            end
+          end
+
+          let(:object) { Class.new{ def hello_world; end }.new }
+
+          it 'does not delegate the public method defined on the object' do
+            decorator = decorator_class.new(object)
+
+            expect{ decorator.hello_world }.to raise_error NoMethodError
+          end
+        end
       end
 
       context ".method_missing" do


### PR DESCRIPTION
Public methods defined on the object was being delegated to the decorator even though it was overridden by a private method.

## Testing
1. Create a simple PORO with a public method
```ruby
class Job
  def location
    Struct.new(:id) { }
  end
end
```

1. Create a decorator and override the public method with a private
```ruby
class JobDecorator < Draper::Decorator
  delegate_all

  private

  def location
    LocationDecorator.new(object.location)
  end
end
```

3. It should raise an exception when calling `.location` from the decorator
```ruby
[9] pry(main)> JobDecorator.decorate(Job.new).location
NoMethodError: private method `location' called for #<JobDecorator:0x0000559f113ba118>
```

## References
* Issue #771  