### PR TITLE
fix: Make CollectionDecorator respond_to? to ORM methods

### DIFF
--- a/lib/draper/query_methods.rb
+++ b/lib/draper/query_methods.rb
@@ -9,6 +9,10 @@ module Draper
       object.send(method, *args, &block).decorate
     end
 
+    def respond_to_missing?(method, include_private = false)
+      strategy.allowed?(method) || super
+    end
+
     private
 
     # Configures the strategy used to proxy the query methods, which defaults to `:active_record`.


### PR DESCRIPTION
## Testing
1. Create a decorator for the model and its association
```ruby
class OrderHistoryDecorator < Draper::Decorator
  delegate_all
end

class OrderDecorator < Draper::Decorator
  delegate_all

  decorates_association :order_histories, with: OrderHistoryDecorator
end
```

2. Call `respond_to?` with some ORM method allowed by the strategy
```ruby
[1] pry(main)> order.order_histories.decorate.respond_to?(:includes)
=> true
```

## References
* method_missing [usage](https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding)
