### PR TITLE
Add SimpleCov for code coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=b7ba588af2a540fa96c267b3655a2afe31ea29976dc25905a668dd28d5e88915
+
 language: ruby
 sudo: false
 cache: bundler
@@ -15,3 +19,11 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![TravisCI Build Status](https://travis-ci.org/drapergem/draper.svg?branch=master)](http://travis-ci.org/drapergem/draper)
 [![Code Climate](https://codeclimate.com/github/drapergem/draper.svg)](https://codeclimate.com/github/drapergem/draper)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/0d40c43951d516bf6985/test_coverage)](https://codeclimate.com/github/drapergem/draper/test_coverage)
 [![Inline docs](http://inch-ci.org/github/drapergem/draper.svg?branch=master)](http://inch-ci.org/github/drapergem/draper)
 
 Draper adds an object-oriented layer of presentation logic to your Rails

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'active_model_serializers', '>= 0.10'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'simplecov'
 end

--- a/spec/draper/draper_spec.rb
+++ b/spec/draper/draper_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'support/shared_examples/view_helpers'
+SimpleCov.command_name 'test:unit'
 
 module Draper
   describe Draper do

--- a/spec/generators/controller/controller_generator_spec.rb
+++ b/spec/generators/controller/controller_generator_spec.rb
@@ -3,6 +3,7 @@ require 'dummy/config/environment'
 require 'ammeter/init'
 require 'generators/controller_override'
 require 'generators/rails/decorator_generator'
+SimpleCov.command_name 'test:generator'
 
 describe Rails::Generators::ControllerGenerator do
   destination File.expand_path("../tmp", __FILE__)

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'support/dummy_app'
 require 'support/matchers/have_text'
+SimpleCov.command_name 'test:integration'
 
 app = DummyApp.new(ENV["RAILS_ENV"])
 spec_types = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec'
+  add_group 'Draper', 'lib/draper'
+  add_group 'Generators', 'lib/generators'
+end
+
 require 'bundler/setup'
 require 'draper'
 require 'action_controller'


### PR DESCRIPTION
Add `simplecov` now become simpler, as it now support merging results for multiple test suites.

## Testing Results
![image](https://user-images.githubusercontent.com/233115/54475149-e89ce980-4828-11e9-89a6-b6d446d4ac06.png)


## To-Dos
- [x] Display test coverage result to `codeclimate` (I can do this)

## References
* [SimpleCov Readme of Merging Results](https://github.com/colszowka/simplecov#merging-results)
* [Deprecated Pull Request](https://github.com/drapergem/draper/pull/769)
