### PR TITLE
Don't require action_controller/test_case

### DIFF
--- a/lib/draper/railtie.rb
+++ b/lib/draper/railtie.rb
@@ -47,7 +47,6 @@ module Draper
     end
 
     def initialize_view_context
-      require 'action_controller/test_case'
       Draper.default_controller.new.view_context
       Draper::ViewContext.build
     end


### PR DESCRIPTION
This was initially introduced in 738074f986507198b9a1862d74dee6a88aa3071b in order to allow draper to work in a rails console session, however this no longer seems necessary.

Requiring this file in non test environments has the consequence of breaking `ActionController::Live` as discussed in [rails issue 31200](https://github.com/rails/rails/issues/31200).