### PR TITLE
Add support for Rails 6.0 to `ViewContext::BuildStrategy`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,11 @@ source "https://rubygems.org"
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3'
+  if RUBY_VERSION >= "2.5.0"
+    gem 'sqlite3'
+  else
+    gem 'sqlite3', '~> 1.3.6'
+  end
 end
 
 platforms :jruby do
@@ -11,5 +15,9 @@ platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"
 end
 
-gem "rails", "~> 6.0"
+if RUBY_VERSION >= "2.5.0"
+  gem "rails", "~> 6.0"
+else
+  gem "rails", "~> 5.0"
+end
 gem "mongoid", github: "mongodb/mongoid"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3', '~> 1.3.6'
+  gem 'sqlite3'
 end
 
 platforms :jruby do
@@ -11,5 +11,5 @@ platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"
 end
 
-gem "rails", "~> 5.0"
+gem "rails", "~> 6.0"
 gem "mongoid", github: "mongodb/mongoid"

--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -12,7 +12,7 @@ module Draper
         end
 
         def call
-          view_context_class.new
+          view_context_class.respond_to?(:empty) ? view_context_class.empty : view_context_class.new
         end
 
         private

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end


### PR DESCRIPTION
## Description

In Rails 6.0 the API for `ActionView::Base.new` is changing.
`ActionView::Base.new` now take arguments [1], otherwise you
will see the following deprecation warning:

```
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller.
```

[1] https://github.com/rails/rails/commit/e17fe52e0e0ef0842b6c409e1110a862c4e005bc

`ViewContext::BuildStrategy::Fast` does not have lookup context, so use `empty`
method instead of `new` to build instance.

## Testing

I'm not sure test policy, so I did not update Rails version of test. But if need, I will update that to 6.0.