### PR TITLE
Add preservation of decorator options on QueryMethods

### DIFF
--- a/lib/draper/query_methods.rb
+++ b/lib/draper/query_methods.rb
@@ -6,7 +6,7 @@ module Draper
     def method_missing(method, *args, &block)
       return super unless strategy.allowed? method
 
-      object.send(method, *args, &block).decorate
+      object.send(method, *args, &block).decorate(with: decorator_class, context: context)
     end
 
     def respond_to_missing?(method, include_private = false)

--- a/spec/draper/query_methods_spec.rb
+++ b/spec/draper/query_methods_spec.rb
@@ -11,7 +11,8 @@ module Draper
 
     describe '#method_missing' do
       let(:collection) { [ Post.new, Post.new ] }
-      let(:collection_decorator) { PostDecorator.decorate_collection(collection) }
+      let(:collection_context) { { user: 'foo' } }
+      let(:collection_decorator) { PostDecorator.decorate_collection(collection, context: collection_context) }
 
       context 'when strategy allows collection to call the method' do
         let(:results) { spy(:results) }
@@ -25,6 +26,12 @@ module Draper
           collection_decorator.some_query_method
 
           expect(results).to have_received(:decorate)
+        end
+
+        it 'calls the method on the collection and keeps the decoration options' do
+          collection_decorator.some_query_method
+
+          expect(results).to have_received(:decorate).with({ context: collection_context, with: PostDecorator })
         end
       end
 


### PR DESCRIPTION
## References
* [GitHub Issue #864](https://github.com/drapergem/draper/issues/864)

## Description
The context given to a Collection Decorator was being lost when an `ActiveRecord::QueryMethod` was being called on a `Draper::CollectionDecorator`.

E.g. 
```rb
decorated_collection = PostDecorator.decorate_collection(Post.all, context: {user: "foo"}).order("created_at asc")
decorated_collection.context #{}
decorated_collection.decorator_class #nil
```

This was happening because `method_missing` on `draper/lib/draper/query_methods.rb` is invoking ActiveRecord method with `send` and creating another instance of decorator to decorate the result.

```draper/lib/draper/query_methods.rb
 def method_missing(method, *args, &block) 
   return super unless strategy.allowed? method 
  
   object.send(method, *args, &block).decorate 
 end 
```

The problem is that the object context and decorator_class were being lost on creation of another instance.
The solution to this was to pass the options alongside the `decorate` call, it creates the instance of `CollectionDecorator` with the old options.

## Testing
The new behaviour of the Collection Decorator is the following.

```rb
decorated_collection = PostDecorator.decorate_collection(Post.all, context: {user: "foo"}).order("created_at asc")
decorated_collection.context #{:user=>"foo"}
decorated_collection.decorator_class #PostDecorator
```

Also added a test to cover this alteration.