### PR TITLE
Remove ruby 2.7 deprecation

### DIFF
--- a/lib/draper/delegation.rb
+++ b/lib/draper/delegation.rb
@@ -7,7 +7,7 @@ module Draper
     #   @return [void]
     def delegate(*methods)
       options = methods.extract_options!
-      super *methods, options.reverse_merge(to: :object)
+      super(*methods, **options.reverse_merge(to: :object))
     end
   end
 end


### PR DESCRIPTION
## Description
Remove ruby 2.7 deprecation
```
lib/ruby/gems/2.7.0/gems/draper-3.1.0/lib/draper/delegation.rb:10: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```
Detail your changes here.  
A few sentences describing the overall goals of the pull request's commits will suffice.
Some questions you might answer:


## References
* [GitHub Issue 869](https://github.com/drapergem/draper/issues/869)
