### PR TITLE
fix alias method

### DIFF
--- a/lib/draper/compatibility/api_only.rb
+++ b/lib/draper/compatibility/api_only.rb
@@ -14,9 +14,9 @@ module Draper
       extend ActiveSupport::Concern
 
       included do
-        alias_method :previous_render_to_body, :render_to_body
+        alias :previous_render_to_body :render_to_body
         include ActionView::Rendering
-        alias_method :render_to_body, :previous_render_to_body
+        alias :render_to_body :previous_render_to_body
       end
     end
   end


### PR DESCRIPTION
## Description

this is missing to change in past pull request. https://github.com/drapergem/draper/pull/852

other changes
```
alias_method :decorate, :new => alias :decorate :new
```

missing changes
```
alias :previous_render_to_body :render_to_body => alias_method :previous_render_to_body, :render_to_body
```

reference: https://github.com/drapergem/draper/pull/852/files#diff-1ca405441e9eec709668800446ec14c2R17

## To-Dos
- [x] tests
- [x] documentation
