### PR TITLE
Avoid Ruby warnings "ambiguous first argument"

### DIFF
--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -217,7 +217,7 @@ module Draper
         it "uses the custom class name" do
           decorator = ProductsDecorator.new([])
 
-          expect(decorator.to_s).to match /ProductsDecorator/
+          expect(decorator.to_s).to match(/ProductsDecorator/)
         end
       end
     end

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -439,7 +439,7 @@ module Draper
       it "returns a detailed description of the decorator" do
         decorator = ProductDecorator.new(double)
 
-        expect(decorator.inspect).to match /#<ProductDecorator:0x\h+ .+>/
+        expect(decorator.inspect).to match(/#<ProductDecorator:0x\h+ .+>/)
       end
 
       it "includes the object" do


### PR DESCRIPTION

## Description

**When running tests**, there were fixable warnings emitted:

```
/Users/olle/opensource/draper/spec/draper/collection_decorator_spec.rb:220: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/olle/opensource/draper/spec/draper/decorator_spec.rb:442: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

Solution: **add parentheses** to disambiguate.

## Testing

1. Observe that test output (with `RUBYOPT=-W2`) does not contain the above warnings.
