### PR TITLE
Cleanup: Initialize instance variable before use to avoid Ruby warnings

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -32,6 +32,7 @@ module Draper
       @object = object
       @decorator_class = options[:with]
       @context = options.fetch(:context, {})
+      @decorated_collection = nil
     end
 
     class << self

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -63,8 +63,8 @@ module Draper
           decorated = CollectionDecorator.new([]).tap(&:to_a)
           undecorated = CollectionDecorator.new([])
 
-          expect(decorated.instance_variable_defined?(:@decorated_collection)).to be_truthy
-          expect(undecorated.instance_variable_defined?(:@decorated_collection)).to be_falsy
+          expect(decorated.instance_variable_get(:@decorated_collection)).not_to be_nil
+          expect(undecorated.instance_variable_get(:@decorated_collection)).to be_nil
         end
 
         it "sets context after decoration is triggered" do


### PR DESCRIPTION
## Description

This avoids a Ruby warning emitted on use.

By initializing the variable before use, this is an easy win against the sea of warnings output.

## Testing

1. Run the test with `RUBYOPT=-W2` 
1. See that `@decorated_collection` is not among the output


