### PR TITLE
Fix kwargs for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.0'
           - '2.7'
           - '2.6'
           - '2.5'

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'request_store', '>= 1.0'
   s.add_dependency 'activemodel', '>= 5.0'
   s.add_dependency 'activemodel-serializers-xml', '>= 1.0'
+  s.add_dependency 'ruby2_keywords'
 
   s.add_development_dependency 'ammeter'
   s.add_development_dependency 'rake'

--- a/lib/draper.rb
+++ b/lib/draper.rb
@@ -8,6 +8,8 @@ require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/name_error'
 
+require 'ruby2_keywords'
+
 require 'draper/version'
 require 'draper/configuration'
 require 'draper/view_helpers'

--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -6,7 +6,7 @@ module Draper
     # method calls to `object` as well. Calling `super` will first try to call the method on
     # the parent decorator class. If no method exists on the parent class, it will then try
     # to call the method on the `object`.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       return super unless delegatable?(method)
 
       object.send(method, *args, &block)
@@ -27,7 +27,7 @@ module Draper
 
     module ClassMethods
       # Proxies missing class methods to the source class.
-      def method_missing(method, *args, &block)
+      ruby2_keywords def method_missing(method, *args, &block)
         return super unless delegatable?(method)
 
         object_class.send(method, *args, &block)

--- a/lib/draper/helper_proxy.rb
+++ b/lib/draper/helper_proxy.rb
@@ -8,7 +8,7 @@ module Draper
     end
 
     # Sends helper methods to the view context.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       self.class.define_proxy method
       send(method, *args, &block)
     end
@@ -31,6 +31,7 @@ module Draper
       define_method name do |*args, &block|
         view_context.send(name, *args, &block)
       end
+      ruby2_keywords name
     end
   end
 end

--- a/lib/draper/lazy_helpers.rb
+++ b/lib/draper/lazy_helpers.rb
@@ -4,7 +4,7 @@ module Draper
   # bazillion methods.
   module LazyHelpers
     # Sends missing methods to the {HelperProxy}.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       helpers.send(method, *args, &block)
     rescue NoMethodError
       super

--- a/lib/draper/query_methods.rb
+++ b/lib/draper/query_methods.rb
@@ -3,7 +3,7 @@ require_relative 'query_methods/load_strategy'
 module Draper
   module QueryMethods
     # Proxies missing query methods to the source class if the strategy allows.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       return super unless strategy.allowed? method
 
       object.send(method, *args, &block).decorate(with: decorator_class, context: context)

--- a/lib/draper/view_helpers.rb
+++ b/lib/draper/view_helpers.rb
@@ -28,7 +28,7 @@ module Draper
 
     # Alias for `helpers.localize`, since localize is something that's used
     # quite often. Further aliased to `l` for convenience.
-    def localize(*args)
+    ruby2_keywords def localize(*args)
       helpers.localize(*args)
     end
 


### PR DESCRIPTION
## Description

Fix kwargs for Ruby 2.7.

## References

- [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
