### PR TITLE
Update BuildStrategy to be compatible with Ruby 2.7

### DIFF
--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -43,11 +43,11 @@ module Draper
         end
 
         def new_test_request(controller)
-          is_above_rails_5_1 ? ActionController::TestRequest.create(controller) : ActionController::TestRequest.create
-        end
-
-        def is_above_rails_5_1
-          ActionController::TestRequest.method(:create).parameters.first == [:req, :controller_class]
+          if ActionController::TestRequest.method(:create).parameters.first.any?
+            ActionController::TestRequest.create(controller)
+          else
+            ActionController::TestRequest.create
+          end
         end
       end
     end


### PR DESCRIPTION
When creating an `ActionController::TestRequest`, the params differ
based on the gem version of ActionPack.

Currently the check asserts the names of the params and expects
them to be `[:req, :controller_class]`. However on Ruby 2.7 this changes
to `[:rest, :args]`.

Rather than check for the names of the params, we can make this more
robust by checking if there are any params. As we know that old versions
of `TestRequest` didn't require any params to create an instance.

The previous workaround was introduced in: [GitHub Pull Request #759](https://github.com/drapergem/draper/pull/759)