### PR TITLE
Fix HelperProxy keyword argument passing for Ruby 3

### DIFF
--- a/lib/draper/helper_proxy.rb
+++ b/lib/draper/helper_proxy.rb
@@ -8,9 +8,9 @@ module Draper
     end
 
     # Sends helper methods to the view context.
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       self.class.define_proxy method
-      send(method, *args, &block)
+      send(method, *args, **kwargs, &block)
     end
 
     # Checks if the context responds to an instance method, or is able to
@@ -28,8 +28,8 @@ module Draper
     private
 
     def self.define_proxy(name)
-      define_method name do |*args, &block|
-        view_context.send(name, *args, &block)
+      define_method name do |*args, **kwargs, &block|
+        view_context.send(name, *args, **kwargs, &block)
       end
     end
   end

--- a/spec/draper/helper_proxy_spec.rb
+++ b/spec/draper/helper_proxy_spec.rb
@@ -22,6 +22,20 @@ module Draper
         expect(helper_proxy.foo(:passed)).to be :passed
       end
 
+      it "proxies methods with keyword arguments to the view context" do
+        view_context = double
+
+        # It seems we can't stub a method using `allow` with keyword
+        # arguments, so we just define it directly
+        def view_context.foo(bar:)
+          bar
+        end
+
+        helper_proxy = HelperProxy.new(view_context)
+
+        expect(helper_proxy.foo(bar: "baz")).to eq "baz"
+      end
+
       it "passes blocks" do
         view_context = double
         helper_proxy = HelperProxy.new(view_context)


### PR DESCRIPTION
It seems Ruby 3 doesn't recognize passed hash arguments as keyword arguments like it did in Ruby 2.7. That's why we need to properly pass keyword arguments.

Fixes #884.