### PR TITLE
Fix decoration spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 
 if RUBY_VERSION >= "2.5.0"
   gem "rails", "~> 6.0"
+  gem 'webrick'
 else
   gem "rails", "~> 5.0"
 end

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'active_model_serializers', '>= 0.10'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov', '0.17.1'
 end

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -60,10 +60,11 @@ module Draper
 
       context "when the collection has not yet been decorated" do
         it "does not trigger decoration" do
-          decorator = CollectionDecorator.new([])
+          decorated = CollectionDecorator.new([]).tap(&:to_a)
+          undecorated = CollectionDecorator.new([])
 
-          expect(decorator).not_to receive(:decorated_collection)
-          decorator.context = {other: "context"}
+          expect(decorated.instance_variable_defined?(:@decorated_collection)).to be_truthy
+          expect(undecorated.instance_variable_defined?(:@decorated_collection)).to be_falsy
         end
 
         it "sets context after decoration is triggered" do

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -30,4 +30,6 @@ Dummy::Application.configure do
 
   # Expands the lines which load the assets
   # config.assets.debug = true
+
+  config.active_storage.service = :local
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -54,4 +54,6 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.active_storage.service = :local
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -30,4 +30,6 @@ Dummy::Application.configure do
   config.eager_load = false
 
   config.active_job.queue_adapter = :test
+
+  config.active_storage.service = :test
 end

--- a/spec/dummy/config/storage.yml
+++ b/spec/dummy/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -40,7 +40,7 @@ describe Rails::Generators::DecoratorGenerator do
 
       context "with an ApplicationDecorator" do
         before do
-          allow_any_instance_of(Object).to receive(:require)
+          allow_any_instance_of(Object).to receive(:require).and_call_original
           allow_any_instance_of(Object).to receive(:require).with("application_decorator").and_return(
             stub_const "ApplicationDecorator", Class.new
           )


### PR DESCRIPTION
Draper::CollectionDecorator#{is_a?,kind_of?} triggers
decorating the object. When stubbing a method call
on a CollectionDecorator, RSpec itself will call #is_a?
on the object. See:

https://github.com/rspec/rspec-mocks/blob/ea4d8ea4532480500462cc7a633d3408656a4dcd/lib/rspec/mocks/proxy.rb#L38

That's why the object will always be decorated when
stubbing a method on it.

We can circumvent this issue by directly checking
the definition of @decorated_collection.

Edit:

This PR got bigger than intended, but it fixes more failing and flaky specs.