### PR TITLE
Add mongo service to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
           - '2.6'
           - '2.5'
           - '2.4'
+
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
This adds the mongo service back into the GitHub actions configuration from #893.

The two failing tests in here should be fixed by #895.