### PR TITLE
Fix Rake warning in CI

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.2.2'

--- a/draper.gemspec
+++ b/draper.gemspec
@@ -1,4 +1,4 @@
-require File.join(__dir__, "lib", "draper", "version")
+require_relative 'lib/draper/version'
 
 Gem::Specification.new do |s|
   s.name        = "draper"

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -693,7 +693,7 @@ module Draper
             decorator = decorator_class.new(object)
 
             # `print` private method is defined on `Object`
-            expect{ decorator.print }.not_to raise_error NoMethodError
+            expect{ decorator.print }.not_to raise_error
           end
         end
       end


### PR DESCRIPTION
The `rake` executable in the `rake` gem is being loaded, but it's also present in other gems (draper).
Draoer doesn't provide any executable, and if it did, it should go in 'exe' dir.

Fix this warning in [CI](https://github.com/drapergem/draper/runs/1704069353?check_suite_focus=true#step:7:9) : 

```sh
The `rake` executable in the `rake` gem is being loaded, but it's also present in other gems (draper).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.
```