### PR TITLE
Ruby272 warnings

### DIFF
--- a/lib/draper/automatic_delegation.rb
+++ b/lib/draper/automatic_delegation.rb
@@ -6,10 +6,10 @@ module Draper
     # method calls to `object` as well. Calling `super` will first try to call the method on
     # the parent decorator class. If no method exists on the parent class, it will then try
     # to call the method on the `object`.
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       return super unless delegatable?(method)
 
-      object.send(method, *args, &block)
+      object.send(method, *args, **kwargs, &block)
     end
 
     # Checks if the decorator responds to an instance method, or is able to
@@ -27,10 +27,10 @@ module Draper
 
     module ClassMethods
       # Proxies missing class methods to the source class.
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         return super unless delegatable?(method)
 
-        object_class.send(method, *args, &block)
+        object_class.send(method, *args, **kwargs, &block)
       end
 
       # Checks if the decorator responds to a class method, or is able to proxy

--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -76,7 +76,7 @@ module Draper
 
     # Decorates the given item.
     def decorate_item(item)
-      item_decorator.call(item, context: context)
+      item_decorator.call(item, { context: context })
     end
 
     private

--- a/lib/draper/helper_proxy.rb
+++ b/lib/draper/helper_proxy.rb
@@ -8,9 +8,9 @@ module Draper
     end
 
     # Sends helper methods to the view context.
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       self.class.define_proxy method
-      send(method, *args, &block)
+      send(method, *args, **kwargs, &block)
     end
 
     # Checks if the context responds to an instance method, or is able to
@@ -28,8 +28,8 @@ module Draper
     private
 
     def self.define_proxy(name)
-      define_method name do |*args, &block|
-        view_context.send(name, *args, &block)
+      define_method name do |*args, **kwargs, &block|
+        view_context.send(name, *args, **kwargs, &block)
       end
     end
   end


### PR DESCRIPTION
```
Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

at 3 files:

- lib/draper/automatic_delegation.rb
- lib/draper/collection_decorator.rb
- lib/draper/helper_proxy.rb

