### PR TITLE
Give namespace example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ class ArticleDecorator < Draper::Decorator
 end
 ```
 
+Namespaced models live in namespaced subdirectories:
+
+```ruby
+# app/decorators/help/article_decorator.rb
+class Help::ArticleDecorator < Draper::Decorator
+# ...
+end
+```
+
 ### Generators
 
 To create an `ApplicationDecorator` that all generated decorators inherit from, run...


### PR DESCRIPTION
## Description
Previously it was not clear how to create a namespaced decorator, so
this adds an example to the README.

## References
This is intended to help resolve apparent difficulty with namespaced models:
* [GitHub Issue 835](https://github.com/drapergem/draper/pull/835)
* [GitHub Issue 809](https://github.com/drapergem/draper/issues/809)
* [GitHub Pull Request 899](https://github.com/drapergem/draper/pull/899)
* and more