### PR TITLE
Replace the Travis CI status badge with the GitHub Actions one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Draper: View Models for Rails
 
-[![TravisCI Build Status](https://travis-ci.org/drapergem/draper.svg?branch=master)](http://travis-ci.org/drapergem/draper)
+[![Actions Status](https://github.com/drapergem/draper/workflows/CI/badge.svg?branch=master)](https://github.com/drapergem/draper/actions?query=workflow%3Aci+branch%3Amaster)
 [![Code Climate](https://codeclimate.com/github/drapergem/draper.svg)](https://codeclimate.com/github/drapergem/draper)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/0d40c43951d516bf6985/test_coverage)](https://codeclimate.com/github/drapergem/draper/test_coverage)
 [![Inline docs](http://inch-ci.org/github/drapergem/draper.svg?branch=master)](http://inch-ci.org/github/drapergem/draper)


### PR DESCRIPTION
## Description

This PR is the follow-up to #893.

In #893, CI is migrated from Travis CI to GitHub Actions.
This patch replaces the Travis CI badge in README with the GitHub Actions one.


