### PR TITLE
fix ruby2.7 kwargs warning with finders method_missing

### DIFF
--- a/lib/draper/finders.rb
+++ b/lib/draper/finders.rb
@@ -20,7 +20,7 @@ module Draper
     end
 
     # Decorates dynamic finder methods (`find_all_by_` and friends).
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       return super unless method =~ /^find_(all_|last_|or_(initialize_|create_))?by_/
 
       result = object_class.send(method, *args, &block)


### PR DESCRIPTION
## Description

Warnings generated by Ruby 2.7 regarding kwargs were fixed with this patch: https://github.com/drapergem/draper/pull/885. However, I ran into a lingering one generated by the `Finders` module `method_missing` method. Adding `ruby2_keywords` to the function header as was done with the other `method_missing` methods from the aforementioned patch resolves the warning.

## References
* https://github.com/drapergem/draper/pull/885
* https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
