### PR TITLE
Use https for GitHub link

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version     = Draper::VERSION
   s.authors     = ["Jeff Casimir", "Steve Klabnik"]
   s.email       = ["jeff@casimircreative.com", "steve@steveklabnik.com"]
-  s.homepage    = "http://github.com/drapergem/draper"
+  s.homepage    = "https://github.com/drapergem/draper"
   s.summary     = "View Models for Rails"
   s.description = "Draper adds an object-oriented layer of presentation logic to your Rails apps."
   s.license     = "MIT"


### PR DESCRIPTION
## Description
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/draper or some tools or APIs that use the gem's metadata.
