### PR TITLE
Add Ruby 3.1 and 3.2 to the CI matrix and fix CI failure in Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.3'
           - '3.2'
           - '3.1'
           - '3.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           bundler-cache: true
 
       - name: RSpec & publish code coverage
-        uses: paambaati/codeclimate-action@v3.2.0
+        uses: paambaati/codeclimate-action@v8
         env:
           CC_TEST_REPORTER_ID: b7ba588af2a540fa96c267b3655a2afe31ea29976dc25905a668dd28d5e88915
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           bundler-cache: true
 
       - name: RSpec & publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: b7ba588af2a540fa96c267b3655a2afe31ea29976dc25905a668dd28d5e88915
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Setup Ruby cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-
-
-      - name: Bundle
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: RSpec & publish code coverage
         uses: paambaati/codeclimate-action@v2.7.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   rspec:
     runs-on: ubuntu-20.04

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,10 @@ else
   gem "rails", "~> 5.0"
 end
 
-if RUBY_VERSION >= "2.6.0"
+if RUBY_VERSION >= "2.7.0"
   gem "mongoid", github: "mongodb/mongoid"
+elsif RUBY_VERSION >= "2.6.0"
+  gem "mongoid", "~> 8.1"
 else
   gem "mongoid", "~> 7.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 platforms :ruby do
   if RUBY_VERSION >= "2.5.0"
-    gem 'sqlite3'
+    gem 'sqlite3', '~> 1.4'
   else
     gem 'sqlite3', '~> 1.3.6'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,9 @@ if RUBY_VERSION >= "2.5.0"
 else
   gem "mongoid", "~> 7.2"
 end
+
+if RUBY_VERSION >= "3.1.0"
+  gem "net-imap"
+  gem "net-pop"
+  gem "net-smtp"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,7 @@ if RUBY_VERSION >= "3.1.0"
   gem "net-pop"
   gem "net-smtp"
 end
+
+if RUBY_VERSION < "2.5.0"
+  gem "loofah", "< 2.21.0" # Workaround for `uninitialized constant Nokogiri::HTML4`
+end

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ else
   gem "rails", "~> 5.0"
 end
 
-if RUBY_VERSION >= "2.5.0"
+if RUBY_VERSION >= "2.6.0"
   gem "mongoid", github: "mongodb/mongoid"
 else
   gem "mongoid", "~> 7.2"

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -147,7 +147,7 @@ module Draper
         scoped = [Product.new]
         allow(Product).to receive(:all).and_return(scoped)
 
-        expect(Product.decorator_class).to receive(:decorate_collection).with(scoped, with: nil).and_return(:decorated_collection)
+        expect(Product.decorator_class).to receive(:decorate_collection).with(scoped, {with: nil}).and_return(:decorated_collection)
         expect(Product.decorate).to be :decorated_collection
       end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -118,7 +118,7 @@ module Draper
         it "creates a CollectionDecorator using itself for each item" do
           object = [Model.new]
 
-          expect(CollectionDecorator).to receive(:new).with(object, with: Decorator)
+          expect(CollectionDecorator).to receive(:new).with(object, {with: Decorator})
           Decorator.decorate_collection(object)
         end
 
@@ -134,7 +134,7 @@ module Draper
         it "creates a custom collection decorator using itself for each item" do
           object = [Model.new]
 
-          expect(ProductsDecorator).to receive(:new).with(object, with: ProductDecorator)
+          expect(ProductsDecorator).to receive(:new).with(object, {with: ProductDecorator})
           ProductDecorator.decorate_collection(object)
         end
 

--- a/spec/draper/factory_spec.rb
+++ b/spec/draper/factory_spec.rb
@@ -73,17 +73,17 @@ module Draper
           worker = ->(*){}
           allow(Factory::Worker).to receive_messages new: worker
 
-          expect(worker).to receive(:call).with(baz: "qux", context: {foo: "bar"})
+          expect(worker).to receive(:call).with({baz: "qux", context: {foo: "bar"}})
           factory.decorate(double, {baz: "qux"})
         end
 
         it "is overridden by explicitly-specified context" do
-          factory = Factory.new(context: {foo: "bar"})
+          factory = Factory.new({context: {foo: "bar"}})
           worker = ->(*){}
           allow(Factory::Worker).to receive_messages new: worker
 
-          expect(worker).to receive(:call).with(context: {baz: "qux"})
-          factory.decorate(double, context: {baz: "qux"})
+          expect(worker).to receive(:call).with({context: {baz: "qux"}})
+          factory.decorate(double, {context: {baz: "qux"}})
         end
       end
     end
@@ -109,7 +109,7 @@ module Draper
           allow(worker).to receive_messages decorator: decorator
           context = {foo: "bar"}
 
-          expect(decorator).to receive(:call).with(anything(), context: context)
+          expect(decorator).to receive(:call).with(anything(), {context: context})
           worker.call(context: ->{ context })
         end
 
@@ -140,7 +140,7 @@ module Draper
           allow(worker).to receive_messages decorator: decorator
           context = {foo: "bar"}
 
-          expect(decorator).to receive(:call).with(anything(), context: context)
+          expect(decorator).to receive(:call).with(anything(), {context: context})
           worker.call(context: context)
         end
       end
@@ -150,7 +150,7 @@ module Draper
         decorator = ->(*){}
         allow(worker).to receive_messages decorator: decorator
 
-        expect(decorator).to receive(:call).with(anything(), foo: "bar")
+        expect(decorator).to receive(:call).with(anything(), {foo: "bar"})
         worker.call(foo: "bar", context_args: [])
       end
     end
@@ -228,7 +228,7 @@ module Draper
               allow(object).to receive(:decorate){ nil }
               worker = Factory::Worker.new(nil, object)
 
-              expect(decorator_class).to receive(:decorate_collection).with(object, foo: "bar", with: nil).and_return(:decorated)
+              expect(decorator_class).to receive(:decorate_collection).with(object, {foo: "bar", with: nil}).and_return(:decorated)
               expect(worker.decorator.call(object, foo: "bar")).to be :decorated
             end
           end


### PR DESCRIPTION
## Description

This PR adds Ruby 3.1 and 3.2 to the CI matrix, and fix CI failure in Ruby 3.
Here are the details:
- **Address CI failure in Ruby 3**
Since [rspec-mocks v3.10.3](https://github.com/rspec/rspec-mocks/blob/main/Changelog.md#3103--2022-01-28), `with` now distinguishes between keyword args and hash in Ruby 3.
See rspec/rspec-mocks#1394 for details.
- **Enable bundler-cache in ruby/setup-ruby**
This reduces code for caching.
- **Add Ruby 3.1 and 3.2 to the CI matrix**
`net-imap`, `net-pop` and `net-smtp` are bundled gems in Ruby 3.1.
So they need to be listed in `Gemfile`.
See https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/ for details.
- **Bump `actions/checkout` from v2 to v3**
- **Add GitHub token permissions for workflow**
  GitHub asks developers to define workflow permissions,
  see below for securing GitHub workflows against supply-chain attacks.
  - https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
  - https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- Use mongoid 7.x with earlier than Ruby 2.6
  - mongoid 8.x requires Ruby 2.6+.
    https://github.com/mongodb/mongoid/blob/3e6956215f7474d90e52865d982624fdeb981a09/mongoid.gemspec#L34
- Bump paambaati/codeclimate-action from v2.7.5 to v3.2.0 