### PR TITLE
Fix CollectionDecorator#respond_to? for non AR collections

### DIFF
--- a/lib/draper/query_methods.rb
+++ b/lib/draper/query_methods.rb
@@ -10,7 +10,7 @@ module Draper
     end
 
     def respond_to_missing?(method, include_private = false)
-      strategy.allowed?(method) || super
+      object.respond_to?(method) && strategy.allowed?(method) || super
     end
 
     private

--- a/spec/draper/query_methods_spec.rb
+++ b/spec/draper/query_methods_spec.rb
@@ -53,14 +53,24 @@ module Draper
       context 'when strategy allows collection to call the method' do
         before do
           allow(fake_strategy).to receive(:allowed?).with(:some_query_method).and_return(true)
+          allow(collection).to receive(:respond_to?).with(:some_query_method).and_return(true)
         end
 
         it { is_expected.to eq(true) }
+
+        context 'and collection does not implement the method' do
+          before do
+            allow(collection).to receive(:respond_to?).with(:some_query_method).and_return(false)
+          end
+
+          it { is_expected.to eq(false) }
+        end
       end
 
       context 'when strategy does not allow collection to call the method' do
         before do
           allow(fake_strategy).to receive(:allowed?).with(:some_query_method).and_return(false)
+          allow(collection).to receive(:respond_to?).with(:some_query_method).and_return(true)
         end
 
         it { is_expected.to eq(false) }


### PR DESCRIPTION
## Description

`Draper::Collection#respond_to?` does not work properly when using a non AR object, eg:

```ruby
class FooDecorator < Draper::Decorator; end  

decorator_collection = FooDecorator.decorate_collection([Object.new])
decorator_collection.respond_to?(:limit) #=> true
decorator_collection.limit(10) # Raises NoMethodError: undefined method `limit' for []:Array   
```

I think `decorator_collection.respond_to?(:limit)` should return `false` for these cases

## Testing

1. Create a empty decorator with: `class FooDecorator < Draper::Decorator; end `
2. Initialize a non AR collection with it: `decorator_collection = FooDecorator.decorate_collection([Object.new])`
3. `decorator_collection.respond_to?(:limit)` should return `false`

## To-Dos
- [x] tests
- [ ] documentation

## References
* [GitHub Issue ####](https://github.com/drapergem/draper/issues/####)
* [GitHub Pull Request ####](https://github.com/drapergem/draper/pull/####)
