### PR TITLE
Update README with config to disable generation of decorator files

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ rails generate decorator Article
 
 ...to create the `ArticleDecorator`.
 
+If you don't want Rails to generate decorator files when generating a new controller,
+you can add the following configuration to your `config/application.rb` file:
+
+```ruby
+config.generators do |g|
+  g.decorator false
+end
+```
+
 ### Accessing Helpers
 
 Normal Rails helpers are still useful for lots of tasks. Both Rails' provided


### PR DESCRIPTION
I added information about generator settings to the README because it was missing.