### PR TITLE
Replace deprecated/removed `File.exists?` alias

### DIFF
--- a/spec/performance/benchmark.rb
+++ b/spec/performance/benchmark.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 Bundler.require :default
 
 require "benchmark"


### PR DESCRIPTION
The alias `File.exists?` was removed in Ruby 3.2:

* https://bugs.ruby-lang.org/issues/17391
* https://rubyreferences.github.io/rubychanges/3.2.html#removals

`File.exist?` has been in Ruby since at least 1.8: https://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F