### PR TITLE
feat: officially support ruby <= 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'

--- a/spec/performance/benchmark.rb
+++ b/spec/performance/benchmark.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 Bundler.require :default
 
 require "benchmark"


### PR DESCRIPTION
## Description
Add Ruby 3.1 and 3.2 to the test matrix.

The performance benchmark was changed to use `File.exist?` as `File.exists?` was deprecated since Ruby 2.1 and finally removed in Ruby 3.2. See 

## Testing
This only changes the CI config and one benchmark.

## References
* https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
* https://bugs.ruby-lang.org/issues/17391