### PR TITLE
fix issue with using draper outside of controller/view context

### DIFF
--- a/lib/draper/view_context/build_strategy.rb
+++ b/lib/draper/view_context/build_strategy.rb
@@ -38,16 +38,8 @@ module Draper
         def controller
           Draper::ViewContext.controller ||= Draper.default_controller.new
           Draper::ViewContext.controller.tap do |controller|
-            controller.request ||= new_test_request controller if defined?(ActionController::TestRequest)
+            controller.request ||= ActionDispatch::TestRequest.create
           end
-        end
-
-        def new_test_request(controller)
-          is_above_rails_5_1 ? ActionController::TestRequest.create(controller) : ActionController::TestRequest.create
-        end
-
-        def is_above_rails_5_1
-          ActionController::TestRequest.method(:create).parameters.first == [:req, :controller_class]
         end
       end
     end

--- a/spec/draper/view_context/build_strategy_spec.rb
+++ b/spec/draper/view_context/build_strategy_spec.rb
@@ -37,29 +37,12 @@ module Draper
 
         expect(controller.request).to be_nil
         strategy.call
-        expect(controller.request).to be_an ActionController::TestRequest
+        expect(controller.request).to be_an ActionDispatch::TestRequest
         expect(controller.params).to be_empty
 
         # sanity checks
         expect(controller.view_context.request).to be controller.request
         expect(controller.view_context.params).to be controller.params
-      end
-
-      it "compatible with rails 5.1 change on ActionController::TestRequest.create method" do
-        ActionController::TestRequest.class_eval do
-          if ActionController::TestRequest.method(:create).parameters.first == []
-            def create controller_class
-              create
-            end
-          end
-        end
-        controller = Class.new(ActionController::Base).new
-        allow(ViewContext).to receive_messages controller: controller
-        strategy = ViewContext::BuildStrategy::Full.new
-
-        expect(controller.request).to be_nil
-        strategy.call
-        expect(controller.request).to be_an ActionController::TestRequest
       end
 
       it "adds methods to the view context from the constructor block" do


### PR DESCRIPTION
## Description

Replace `ActionController::TestRequest` with `ActionDispatch::TestRequest`

because
1) soft deprecated
2) will cause very hard to predict/test failures with ActiveJob/Sidekiq/Rake tasks. see #926 

The current PR also drops support for rails < 6.0 
I think this is a good idea (especially as the tests that were dropped were written from a Rails 5.0 perspective, so are very outdated, and brittle) but open to discussion around this if there's any engagement on this PR.

## Testing

See #926 

## To-Dos

- [ ] tests: I have not done additional tests to prove the need for the PR as they are hard to implement and harder to maintain and wouldn't catch regressions in any case.
- [ ] documentation: unnecessary I think

## References
* [GitHub Issue 926](https://github.com/drapergem/draper/issues926)

fixes #926

