### PR TITLE
Integration with `Turbo::Broadcastable`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,11 @@ platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"
 end
 
+if RUBY_VERSION >= "2.6.0"
+  gem "turbo-rails"
+  gem "redis", "~> 4.0"
+end
+
 if RUBY_VERSION >= "2.5.0"
   gem "rails", "~> 6.0"
   gem 'webrick'

--- a/lib/draper/compatibility/broadcastable.rb
+++ b/lib/draper/compatibility/broadcastable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Draper
+  module Compatibility
+    # It would look consistent to use decorated objects inside templates broadcasted with
+    # Turbo::Broadcastable.
+    #
+    # This compatibility patch fixes the issue by overriding the original defaults to decorate the
+    # object, that's passed to the partial in a local variable.
+    module Broadcastable
+      private
+
+      def broadcast_rendering_with_defaults(options)
+        return super unless decorator_class?
+
+        # Add the decorated current instance into the locals (see original method for details).
+        options[:locals] =
+          (options[:locals] || {}).reverse_merge!(model_name.element.to_sym => decorate)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/draper/decoratable.rb
+++ b/lib/draper/decoratable.rb
@@ -1,4 +1,5 @@
 require 'draper/decoratable/equality'
+require 'draper/compatibility/broadcastable'
 
 module Draper
   # Provides shortcuts to decorate objects directly, so you can do
@@ -10,6 +11,10 @@ module Draper
   module Decoratable
     extend ActiveSupport::Concern
     include Draper::Decoratable::Equality
+
+    included do
+      prepend Draper::Compatibility::Broadcastable if defined? Turbo::Broadcastable
+    end
 
     # Decorates the object using the inferred {#decorator_class}.
     # @param [Hash] options
@@ -87,8 +92,6 @@ module Draper
       def ===(other)
         super || (other.is_a?(Draper::Decorator) && super(other.object))
       end
-
     end
-
   end
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,3 +1,7 @@
+require 'turbo/broadcastable' if defined? Turbo::Broadcastable # HACK: looks weird, but works
+
 class Post < ApplicationRecord
   # attr_accessible :title, :body
+
+  broadcasts if defined? Turbo::Broadcastable
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,6 +9,7 @@ require 'rails/all'
 require 'draper'
 attempt_require 'mongoid'
 attempt_require 'devise'
+attempt_require 'turbo-rails'
 require 'active_model_serializers'
 
 module Dummy

--- a/spec/dummy/config/cable.yml
+++ b/spec/dummy/config/cable.yml
@@ -1,0 +1,8 @@
+# production:
+#   url: redis://redis.example.com:6379
+
+local: &local
+  url: redis://localhost:6379
+
+development: *local
+test:        *local

--- a/spec/dummy/spec/models/post_spec.rb
+++ b/spec/dummy/spec/models/post_spec.rb
@@ -5,4 +5,17 @@ RSpec.describe Post do
   it_behaves_like 'a decoratable model'
 
   it { should be_a ApplicationRecord }
+
+  describe 'broadcasts' do
+    let(:modification) { described_class.create! }
+
+    it 'passes a decorated object for rendering' do
+      expect do
+        modification
+      end.to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).with { |stream, action:, target:, **rendering|
+        expect(rendering[:locals]).to include :post
+        expect(rendering[:locals][:post]).to be_decorated
+      }
+    end
+  end if defined? Turbo::Broadcastable
 end


### PR DESCRIPTION
## Description
Overriding defaults for Turbo broadcast jobs allows one to get decorated objects in model partials by default.

## Testing

1. Broadcast an object with Turbo.
2. Check if the local variable passed into the partial is decorated.

## To-Dos
- [x] tests
- [x] documentation

## References
* Resolves [#910](https://github.com/drapergem/draper/issues/910)
* Depends on [#928](https://github.com/drapergem/draper/pull/928)
