### PR TITLE
Revert class spoofing

### DIFF
--- a/lib/draper/collection_decorator.rb
+++ b/lib/draper/collection_decorator.rb
@@ -61,12 +61,6 @@ module Draper
 
     alias :decorated_with? :instance_of?
 
-    def kind_of?(klass)
-      decorated_collection.kind_of?(klass) || super
-    end
-
-    alias_method :is_a?, :kind_of?
-
     def replace(other)
       decorated_collection.replace(other)
       self

--- a/lib/draper/decorator.rb
+++ b/lib/draper/decorator.rb
@@ -33,7 +33,7 @@ module Draper
       options.assert_valid_keys(:context)
       @object = object
       @context = options.fetch(:context, {})
-      handle_multiple_decoration(options) if object.instance_of?(self.class)
+      handle_multiple_decoration(options) if object.is_a?(Draper::Decorator)
     end
 
     class << self
@@ -185,22 +185,6 @@ module Draper
       self.class.hash ^ object.hash
     end
 
-    # Checks if `self.kind_of?(klass)` or `object.kind_of?(klass)`
-    #
-    # @param [Class] klass
-    def kind_of?(klass)
-      super || object.kind_of?(klass)
-    end
-
-    alias :is_a? :kind_of?
-
-    # Checks if `self.instance_of?(klass)` or `object.instance_of?(klass)`
-    #
-    # @param [Class] klass
-    def instance_of?(klass)
-      super || object.instance_of?(klass)
-    end
-
     delegate :to_s
 
     # In case object is nil
@@ -267,7 +251,7 @@ module Draper
       if object.applied_decorators.last == self.class
         @context = object.context unless options.has_key?(:context)
         @object = object.object
-      else
+      elsif object.applied_decorators.include?(self.class)
         warn "Reapplying #{self.class} decorator to target that is already decorated with it. Call stack:\n#{caller(1).join("\n")}"
       end
     end

--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -249,29 +249,6 @@ module Draper
       end
     end
 
-    describe '#kind_of?' do
-      it 'asks the kind of its decorated collection' do
-        decorator = ProductsDecorator.new([])
-        expect(decorator.decorated_collection).to receive(:kind_of?).with(Array).and_return("true")
-        expect(decorator.kind_of?(Array)).to eq "true"
-      end
-
-      context 'when asking the underlying collection returns false' do
-        it 'asks the CollectionDecorator instance itself' do
-          decorator = ProductsDecorator.new([])
-          allow(decorator.decorated_collection).to receive(:kind_of?).with(::Draper::CollectionDecorator).and_return(false)
-          expect(decorator.kind_of?(::Draper::CollectionDecorator)).to be true
-        end
-      end
-    end
-
-    describe '#is_a?' do
-      it 'aliases to #kind_of?' do
-        decorator = ProductsDecorator.new([])
-        expect(decorator.method(:kind_of?)).to eq decorator.method(:is_a?)
-      end
-    end
-
     describe "#replace" do
       it "replaces the decorated collection" do
         decorator = CollectionDecorator.new([Product.new])

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -800,34 +800,6 @@ module Draper
       end
     end
 
-    describe "class spoofing" do
-      it "pretends to be a kind of the object class" do
-        decorator = Decorator.new(Model.new)
-
-        expect(decorator.kind_of?(Model)).to be_truthy
-        expect(decorator.is_a?(Model)).to be_truthy
-      end
-
-      it "is still a kind of its own class" do
-        decorator = Decorator.new(Model.new)
-
-        expect(decorator.kind_of?(Decorator)).to be_truthy
-        expect(decorator.is_a?(Decorator)).to be_truthy
-      end
-
-      it "pretends to be an instance of the object class" do
-        decorator = Decorator.new(Model.new)
-
-        expect(decorator.instance_of?(Model)).to be_truthy
-      end
-
-      it "is still an instance of its own class" do
-        decorator = Decorator.new(Model.new)
-
-        expect(decorator.instance_of?(Decorator)).to be_truthy
-      end
-    end
-
     describe ".decorates_finders" do
       protect_class Decorator
 


### PR DESCRIPTION
Decorators shouldn't pretend to be instances of the underlying model  classes for the following reasons:

1. It's terribly wrong to pretend being a class without implementing  it's interface. It can break third party code.
2. Hacking Ruby core methods can lead to unexpected and hard to  understand behavior. It should be avoided without a strong reason  behind.
3. I'd prefer compatibility patches to be narrow-scoped and live in  there own modules.

## References

* #72
* #110
* #417
* #497
* #859