### PR TITLE
CI against Rails 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - 3.2
           - 3.1
         rails:
+          - 8.0
           - 7.2
         include:
           # Edge
@@ -35,6 +36,8 @@ jobs:
           - { ruby: '2.6',  rails: '6'   }
           - { ruby: '2.5',  rails: '6'   }
           - { ruby: '2.4',  rails: '5'   }
+        exclude:
+          - { ruby: '3.1',  rails: '8.0'  }
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"


### PR DESCRIPTION
## Description

Rails 8.0 has been released. I would like to confirm whether `draper` works well with it.