### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 3.4
           - 3.3
           - 3.2
           - 3.1

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -451,7 +451,7 @@ module Draper
       it "includes the context" do
         decorator = Decorator.new(double, context: {foo: "bar"})
 
-        expect(decorator.inspect).to include '@context={:foo=>"bar"}'
+        expect(decorator.inspect).to include "#{@context={:foo=>"bar"}}"
       end
 
       it "includes other instance variables" do

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -451,7 +451,7 @@ module Draper
       it "includes the context" do
         decorator = Decorator.new(double, context: {foo: "bar"})
 
-        expect(decorator.inspect).to include "#{@context={:foo=>"bar"}}"
+        expect(decorator.inspect).to include "@context=#{{foo: "bar"}}"
       end
 
       it "includes other instance variables" do


### PR DESCRIPTION
## Description

Ruby 3.4 has been released. I would like to add Ruby 3.4 to CI to confirm whether `draper` works well with it.