### PR TITLE
Use Ubuntu 22.04 image to fix broken Ruby 2.4 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: >-
       rspec (${{ matrix.ruby }})
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Ubuntu-latest workflows use Ubuntu-24.04 image now.
https://github.com/actions/runner-images/issues/10636

But, it seems that old sqlite3 gem(for Ruby 2.4) doesn't work with it.
https://github.com/drapergem/draper/actions/runs/12762245525/job/35570471534?pr=940

So I fixed it to use Ubuntu 22.04. It may be better to use Ubuntu 22.04 only for Ruby 2.4.  But, it would be complex. 
Ubuntu 22.04 will be supported by Apr 2027. So it's OK to keep using it so far(And we should drop old Ruby versions before that).