### PR TITLE
Release version 4.0.4, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Draper Changelog
 
+## 4.0.4 - 2025-01-28
+
+### Fixes
+* Fix a `LoadError` caused by a cherry-pick issue in version 4.0.3
+
+## 4.0.3 - 2025-01-27
+
+Added support for latest Ruby (upto 3.4) and Rails (upto 8) versions.
+
+### Fixes
+* Fix `CollectionDecorator#respond_to?` for non-ORM collections [#920](https://github.com/drapergem/draper/pull/920)
+* Fix issues with using Draper outside of controller scope [#927](https://github.com/drapergem/draper/pull/927)
+* Fix decoration of AR associations [#932](https://github.com/drapergem/draper/pull/932)
+
+### Other Changes
+* Improve performance of delegation via `delegate_all` [#911](https://github.com/drapergem/draper/pull/911)
+* Improve README [#878](https://github.com/drapergem/draper/pull/878), [#922](https://github.com/drapergem/draper/pull/922), [#934](https://github.com/drapergem/draper/pull/934)
+
 ## 4.0.2 - 2021-05-27
 
 ### Fixes

--- a/lib/draper/version.rb
+++ b/lib/draper/version.rb
@@ -1,3 +1,3 @@
 module Draper
-  VERSION = '4.0.2'
+  VERSION = '4.1.0-pre'
 end


### PR DESCRIPTION
Fixes https://github.com/drapergem/draper/issues/941#issuecomment-2617490431

I've pushed the updated version to the `v4.0.4` git tag. You can see the diff here: https://github.com/drapergem/draper/compare/v4.0.3...v4.0.4

I'll hold off on publishing it to rubygems until this PR is approved.