### PR TITLE
Enable transactional fixtures in dummy app's specs

### DIFF
--- a/spec/dummy/spec/rails_helper.rb
+++ b/spec/dummy/spec/rails_helper.rb
@@ -39,7 +39,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  # config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = true
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false


### PR DESCRIPTION
This wraps each example in a transaction that's rolled back at the end of the example to avoid records leaking from one test to the next.

Without this, if you repeatedly run tests, your database will repeatedly grow, and depending on your assertions, may fail due to data from previous test runs.

CI wouldn't have surfaced this issue as it creates a new DB for each run.