### PR TITLE
Remove unused files from package

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -10,8 +10,15 @@ Gem::Specification.new do |s|
   s.description = "Draper adds an object-oriented layer of presentation logic to your Rails apps."
   s.license     = "MIT"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
+  s.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git appveyor Gemfile])
+    end
+  end
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.2.2'


### PR DESCRIPTION
## Description

The `.gemspec` file to optimize the gem package size and structure. The changes include:

- Modified `files` to exclude test files, Gemfile, and CI related files from the package.
- Removed the deprecated `test_files` specification as it is no longer recommended.

These changes reduce the extracted package size from from 1.1MB to 340KB.

Benefits:

- Shorter download times for users
- Reduced container sizes when the gem is included

## References

- https://github.com/rubygems/guides/issues/90
- https://github.com/rubygems/bundler/pull/3207
- [Template for the *.gemspec file generated by bundle gem command](https://github.com/rubygems/rubygems/blob/bundler-v2.6.5/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt)
