### PR TITLE
Set timeout for GitHub Action Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   rspec:
+    timeout-minutes: 10
     name: >-
       rspec (${{ matrix.ruby }})
 


### PR DESCRIPTION

## Description

Basically, our test suite finishes in minutes.
If it's over ten minutes, there is an issue(e.g. https://github.com/drapergem/draper/actions/runs/19391461282/job/55486115122?pr=953)

In that time, it's better to cancel it I think. So I would like to set a timeout.
