### PR TITLE
Temporarily exclude Ruby 3.2 build with Rails 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         exclude:
           - { ruby: '3.1',  rails: '8.0'  }
           - { ruby: '3.1',  rails: '8.1'  }
+          - { ruby: '3.2',  rails: '8.1'  } # FIXME: Temporarily exclude because it's unstable.
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"


### PR DESCRIPTION
## Description

I am investigating unstable tests in #955. 
It seems that it often happens in the DB setup for `production` environment with Ruby 3.2 + Rails 8.1 build.

I'm sure why yet, unstable build prevents other PRs. So I would like to disable it temporarily.
I think disabling isn't a big issue because Ruby 3.2 and Rails 8.1 tests are running with other combinations.